### PR TITLE
append related models to responses based on input request

### DIFF
--- a/app/Ship/Engine/Traits/ResponseTrait.php
+++ b/app/Ship/Engine/Traits/ResponseTrait.php
@@ -2,6 +2,7 @@
 
 namespace App\Ship\Engine\Traits;
 
+use Request;
 use Fractal;
 use Illuminate\Http\JsonResponse;
 use ReflectionClass;

--- a/app/Ship/Engine/Traits/ResponseTrait.php
+++ b/app/Ship/Engine/Traits/ResponseTrait.php
@@ -34,6 +34,10 @@ trait ResponseTrait
             $transformer->setDefaultIncludes($includes);
         }
 
+        if (!empty($requestIncludes = Request::get('include', null))) {
+            $transformer->setDefaultIncludes(explode(',', $requestIncludes));
+        }
+
         return Fractal::create($data, $transformer)->addMeta($this->metaData)->toJson();
     }
 


### PR DESCRIPTION
This brings back the missing **Relations** feature described on [apiato Supported Parameters docs](http://apiato.io/C.features/supported-parameters/).