### PR TITLE
small fix

### DIFF
--- a/app/Ship/Engine/Traits/ResponseTrait.php
+++ b/app/Ship/Engine/Traits/ResponseTrait.php
@@ -131,6 +131,11 @@ trait ResponseTrait
     {
         foreach ($responseArray as $k => $v)
         {
+            if(in_array($k, $filters, true)) {
+                // we have found our element - so continue with the next one
+                continue;
+            }
+
             if (is_array($v))
             {
                 // it is an array - so go one step deeper


### PR DESCRIPTION
Small fix for the previous commits:
Allow `?filter=...` to access arrays (and leave them untouched in the transformed response)