### PR TITLE
[fix] DefaultIncludes

### DIFF
--- a/app/Ship/Engine/Traits/ResponseTrait.php
+++ b/app/Ship/Engine/Traits/ResponseTrait.php
@@ -37,6 +37,7 @@ trait ResponseTrait
         }
 
         if($includes){
+            $includes = array_unique(array_merge($transformer->getDefaultIncludes(), $includes));
             $transformer->setDefaultIncludes($includes);
         }
 


### PR DESCRIPTION
fixes a "bug", where the "defaultIncludes" of a `Transformer` are ignored if you use the `?include=xxx` query parameter on an URI..