### PR TITLE
Enhance Transformer

### DIFF
--- a/app/Ship/Engine/Traits/ResponseTrait.php
+++ b/app/Ship/Engine/Traits/ResponseTrait.php
@@ -22,12 +22,13 @@ trait ResponseTrait
 
     /**
      * @param            $data
-     * @param null       $transformerName
+     * @param null $transformerName
      * @param array|null $includes
+     * @param array $meta
      *
-     * @return  mixed
+     * @return mixed
      */
-    public function transform($data, $transformerName = null, array $includes = null)
+    public function transform($data, $transformerName = null, array $includes = null, array $meta = [])
     {
         $transformer = new $transformerName;
 
@@ -40,6 +41,12 @@ trait ResponseTrait
             $includes = array_unique(array_merge($transformer->getDefaultIncludes(), $includes));
             $transformer->setDefaultIncludes($includes);
         }
+
+        // add specific meta information to the response message
+        $this->metaData = [
+            'include' => $transformer->getAvailableIncludes(),
+            'custom' => $meta,
+        ];
 
         $fractal = Fractal::create($data, $transformer)->addMeta($this->metaData);
 


### PR DESCRIPTION
* Adds the `includes` field to the `meta` block within a transformer. This field indicates all availabe includes for this resource
* Adds the `custom` field to the `meta` block. Can contain application/user-specific information