### PR TITLE
Add route to easily access your "own" profile

### DIFF
--- a/app/Containers/User/Actions/GetMyProfileAction.php
+++ b/app/Containers/User/Actions/GetMyProfileAction.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Containers\User\Actions;
+
+use App\Containers\Authentication\Tasks\GetAuthenticatedUserTask;
+use App\Ship\Parents\Actions\Action;
+use App\Ship\Parents\Requests\Request;
+
+class GetMyProfileAction extends Action
+{
+    public function run(Request $request)
+    {
+        $user = $this->call(GetAuthenticatedUserTask::class);
+
+        return $user;
+    }
+}

--- a/app/Containers/User/Data/Seeders/UserPermissionsSeeder_1.php
+++ b/app/Containers/User/Data/Seeders/UserPermissionsSeeder_1.php
@@ -2,7 +2,6 @@
 
 namespace App\Containers\User\Data\Seeders;
 
-use App\Containers\Authorization\Actions\CreatePermissionAction;
 use App\Containers\Authorization\Tasks\CreatePermissionTask;
 use App\Ship\Parents\Seeders\Seeder;
 use Illuminate\Support\Facades\App;

--- a/app/Containers/User/UI/API/Controllers/Controller.php
+++ b/app/Containers/User/UI/API/Controllers/Controller.php
@@ -5,6 +5,7 @@ namespace App\Containers\User\UI\API\Controllers;
 use App\Containers\User\Actions\CreateAdminAction;
 use App\Containers\User\Actions\DeleteUserAction;
 use App\Containers\User\Actions\GetAuthenticatedUserAction;
+use App\Containers\User\Actions\GetMyProfileAction;
 use App\Containers\User\Actions\GetUserAction;
 use App\Containers\User\Actions\ListAdminsAction;
 use App\Containers\User\Actions\ListAndSearchUsersAction;
@@ -14,6 +15,7 @@ use App\Containers\User\Actions\UpdateUserAction;
 use App\Containers\User\UI\API\Requests\CreateAdminRequest;
 use App\Containers\User\UI\API\Requests\DeleteUserRequest;
 use App\Containers\User\UI\API\Requests\GetAuthenticatedUserRequest;
+use App\Containers\User\UI\API\Requests\GetMyProfileRequest;
 use App\Containers\User\UI\API\Requests\GetUserByIdRequest;
 use App\Containers\User\UI\API\Requests\ListAllUsersRequest;
 use App\Containers\User\UI\API\Requests\RegisterUserRequest;
@@ -123,6 +125,18 @@ class Controller extends ApiController
         $user = $this->call(GetUserAction::class, [$request]);
 
         return $this->transform($user, UserTransformer::class);
+    }
+
+    /**
+     * @param GetMyProfileRequest $request
+     *
+     * @return mixed
+     */
+    public function getMyProfile(GetMyProfileRequest $request)
+    {
+        $user = $this->call(GetMyProfileAction::class, [$request]);
+
+        return $this->transform($user, UserTransformer::class, ['roles']);
     }
 
     /**

--- a/app/Containers/User/UI/API/Requests/GetMyProfileRequest.php
+++ b/app/Containers/User/UI/API/Requests/GetMyProfileRequest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Containers\User\UI\API\Requests;
+
+use App\Ship\Parents\Requests\Request;
+
+/**
+ * Class GetMyProfileRequest.
+ */
+class GetMyProfileRequest extends Request
+{
+    /**
+     * Define which Roles and/or Permissions has access to this request.
+     *
+     * @var  array
+     */
+    protected $access = [
+        'permissions' => '',
+        'roles'       => '',
+    ];
+
+    /**
+     * Id's that needs decoding before applying the validation rules.
+     *
+     * @var  array
+     */
+    protected $decode = [
+        // 'id',
+    ];
+
+    /**
+     * Defining the URL parameters (e.g, `/user/{id}`) allows applying
+     * validation rules on them and allows accessing them like request data.
+     *
+     * @var  array
+     */
+    protected $urlParameters = [
+        //'id',
+    ];
+
+    /**
+     * @return  array
+     */
+    public function rules()
+    {
+        return [
+            // put your rules here
+            // 'name' => 'required|max:255'
+        ];
+    }
+
+    /**
+     * @return  bool
+     */
+    public function authorize()
+    {
+        return $this->check([
+            'hasAccess',
+        ]);
+    }
+}

--- a/app/Containers/User/UI/API/Routes/GetMyProfile.v1.private.php
+++ b/app/Containers/User/UI/API/Routes/GetMyProfile.v1.private.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @apiGroup           User
+ * @apiName            getMyProfile
+ *
+ * @api                {GET} /v1/my/profile Get own User
+ * @apiDescription     Get the own profile (some sort of alias for GET /users/xyz - however, you don't need to specify the ID)
+ *
+ * @apiVersion         1.0.0
+ * @apiPermission      none
+ *
+ * @apiParam           {String}  parameters here..
+ *
+ * @apiSuccessExample  {json}  Success-Response:
+ * HTTP/1.1 200 OK
+{
+  // Insert the response of the request here...
+}
+ */
+
+$router->get('my/profile', [
+    'uses'  => 'Controller@getMyProfile',
+    'middleware' => [
+      'auth:api',
+    ],
+]);

--- a/app/Containers/User/UI/API/Tests/Functional/ListAllAdminsTest.php
+++ b/app/Containers/User/UI/API/Tests/Functional/ListAllAdminsTest.php
@@ -2,7 +2,6 @@
 
 namespace App\Containers\User\UI\API\Tests\Functional;
 
-use App\Containers\Authorization\Models\Role;
 use App\Containers\User\Models\User;
 use App\Containers\User\Tests\TestCase;
 


### PR DESCRIPTION
Currently you need to call `/users/ID` in order to get your own profile. However, if you do not know your `ID`, it is not possible to get it ;)

Therefore, i have created a `/my/profile` route, which returns the respective profile for the currently logged in user!

I know, that there is a dependency between the `User` and `Authentication` Container, but i need to get the logged in user!