### PR TITLE
Fix namespace naming

### DIFF
--- a/app/Containers/Application/UI/CLI/Commands/Name.php
+++ b/app/Containers/Application/UI/CLI/Commands/Name.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Containers\Application\UI\CLI\Commands;
+
+use App\Ship\Parents\Commands\ConsoleCommand;
+use Illuminate\Filesystem\Filesystem;
+
+/**
+ * Class Name
+ *
+ * @author  Nasrul Hazim  <nasrulhazim.m@gmail.com>
+ */
+class Name extends ConsoleCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $signature = 'apiato:name {name}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Set apiato namespace';
+
+    /**
+     * @var  \Illuminate\Filesystem\Filesystem
+     */
+    private $files;
+
+    /**
+     * Current root application namespace.
+     *
+     * @var string
+     */
+    protected $currentRoot;
+
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+    }
+
+    public function handle()
+    {
+        $this->currentRoot = trim($this->laravel->getNamespace(), '\\');
+        $this->info('Change namespace from ' . $this->currentRoot . ' to ' . $this->argument('name'));
+        $this->setApiatoNamespaces();
+    }
+
+    /**
+     * Set the Apiato namespaces.
+     *
+     * @return void
+     */
+    protected function setApiatoNamespaces()
+    {
+        $this->call('app:name', [
+            'name' => $this->argument('name'),
+        ]);
+        $this->setBootstrapNamespaces();
+        $this->setAppConfigNamespaces();
+    }
+
+    /**
+     * Set the bootstrap namespaces.
+     *
+     * @return void
+     */
+    protected function setBootstrapNamespaces()
+    {
+        $search = [
+            $this->currentRoot . '\\Ship\\Engine\\Kernels',
+            $this->currentRoot . '\\Ship\\Engine\\Exceptions',
+        ];
+
+        $replace = [
+            $this->argument('name') . '\\Ship\\Engine\\Kernels',
+            $this->argument('name') . '\\Ship\\Engine\\Exceptions',
+        ];
+
+        $this->replaceIn($this->getBootstrapPath(), $search, $replace);
+    }
+
+    /**
+     * Set the application provider namespaces.
+     *
+     * @return void
+     */
+    protected function setAppConfigNamespaces()
+    {
+        $search = [
+            $this->currentRoot . '\\Ship\\Engine\\Providers',
+        ];
+
+        $replace = [
+            $this->argument('name') . '\\Ship\\Engine\\Providers',
+        ];
+
+        $this->replaceIn($this->getConfigPath('app'), $search, $replace);
+    }
+
+    /**
+     * Get the path to the bootstrap/app.php file.
+     *
+     * @return string
+     */
+    protected function getBootstrapPath()
+    {
+        return $this->laravel->bootstrapPath() . '/app.php';
+    }
+
+    /**
+     * Get the path to the given configuration file.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getConfigPath($name)
+    {
+        return $this->laravel['path.config'] . '/' . $name . '.php';
+    }
+
+    /**
+     * Replace the given string in the given file.
+     *
+     * @param  string  $path
+     * @param  string|array  $search
+     * @param  string|array  $replace
+     * @return void
+     */
+    protected function replaceIn($path, $search, $replace)
+    {
+        if ($this->files->exists($path)) {
+            $this->files->put($path, str_replace($search, $replace, $this->files->get($path)));
+        }
+    }
+}

--- a/app/Containers/Application/composer.json
+++ b/app/Containers/Application/composer.json
@@ -1,0 +1,7 @@
+{
+  "name": "apiato/application",
+  "description": "apiato application",
+  "require": {
+   
+  }
+}


### PR DESCRIPTION
This PR refer to issue #189 .

What it does basically to rename application namespace properly since naming convention used in [apiato/config/app.php](https://github.com/apiato/apiato/blob/master/config/app.php) and [apiato/bootstrap/app.php](https://github.com/apiato/apiato/blob/master/bootstrap/app.php) is not a standard namespaces used in Laravel default setup.