### PR TITLE
Disable Pagination on Requests

### DIFF
--- a/app/Ship/Parents/Repositories/Repository.php
+++ b/app/Ship/Parents/Repositories/Repository.php
@@ -67,6 +67,11 @@ abstract class Repository extends PrettusRepository implements PrettusCacheable
         // it from the request if available and if not keep it null.
         $limit = $limit ? : Request::get('limit');
 
+        // disable the pagination if the limit is set to 0
+        if($limit == "0") {
+            return parent::all($columns);
+        }
+
         return parent::paginate($limit, $columns, $method);
     }
 


### PR DESCRIPTION
This fix lets requestors disable pagination by simply adding `?limit=0` to the URL. Otherwise it is not possible to circumvent a paginated resultset, if the dev used `return $repository->paginate()`.

This can be handy, if a full-blown client with stable and broadband connection would like to fetch all data. Mobile clients, however, would still get a paginated result!