### PR TITLE
Feature/add resource key to json api transformer

### DIFF
--- a/app/Containers/Authorization/Models/Permission.php
+++ b/app/Containers/Authorization/Models/Permission.php
@@ -3,6 +3,7 @@
 namespace App\Containers\Authorization\Models;
 
 use Apiato\Core\Traits\HashIdTrait;
+use Apiato\Core\Traits\HasResourceKeyTrait;
 use Spatie\Permission\Models\Permission as LaratrustPermission;
 
 /**
@@ -14,6 +15,7 @@ class Permission extends LaratrustPermission
 {
 
     use HashIdTrait;
+    use HasResourceKeyTrait;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Containers/Authorization/Models/Role.php
+++ b/app/Containers/Authorization/Models/Role.php
@@ -3,6 +3,7 @@
 namespace App\Containers\Authorization\Models;
 
 use Apiato\Core\Traits\HashIdTrait;
+use Apiato\Core\Traits\HasResourceKeyTrait;
 use Spatie\Permission\Models\Role as LaratrustRole;
 
 /**
@@ -14,6 +15,7 @@ class Role extends LaratrustRole
 {
 
     use HashIdTrait;
+    use HasResourceKeyTrait;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Containers/Authorization/Tasks/ListAllPermissionsTask.php
+++ b/app/Containers/Authorization/Tasks/ListAllPermissionsTask.php
@@ -14,11 +14,26 @@ use Illuminate\Support\Facades\App;
 class ListAllPermissionsTask extends Task
 {
     /**
+     * @var PermissionRepository
+     */
+    private $repository;
+
+    /**
+     * ListAllPermissionsTask constructor.
+     *
+     * @param PermissionRepository $repository
+     */
+    public function __construct(PermissionRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
      * @return  mixed
      */
     public function run()
     {
-        return App::make(PermissionRepository::class)->all();
+        return $this->repository->all();
     }
 
 }

--- a/app/Containers/Authorization/UI/API/Controllers/Controller.php
+++ b/app/Containers/Authorization/UI/API/Controllers/Controller.php
@@ -16,7 +16,6 @@ use App\Containers\Authorization\Actions\SyncPermissionsOnRoleAction;
 use App\Containers\Authorization\Actions\SyncUserRolesAction;
 use App\Containers\Authorization\UI\API\Requests\AssignUserToRoleRequest;
 use App\Containers\Authorization\UI\API\Requests\AttachPermissionToRoleRequest;
-use App\Containers\Authorization\UI\API\Requests\CreatePermissionRequest;
 use App\Containers\Authorization\UI\API\Requests\CreateRoleRequest;
 use App\Containers\Authorization\UI\API\Requests\DeleteRoleRequest;
 use App\Containers\Authorization\UI\API\Requests\DetachPermissionToRoleRequest;

--- a/app/Ship/Parents/Models/UserModel.php
+++ b/app/Ship/Parents/Models/UserModel.php
@@ -4,6 +4,7 @@ namespace App\Ship\Parents\Models;
 
 use Apiato\Core\Abstracts\Models\UserModel as AbstractUserModel;
 use Apiato\Core\Traits\HashIdTrait;
+use Apiato\Core\Traits\HasResourceKeyTrait;
 use App\Containers\Authorization\Traits\AuthorizationTrait;
 use App\Ship\Payment\Contracts\ChargeableInterface;
 use App\Ship\Payment\Traits\ChargeableTrait;
@@ -27,5 +28,6 @@ abstract class UserModel extends AbstractUserModel implements ChargeableInterfac
     use HasRoles;
     use HasApiTokens;
     use ChargeableTrait;
+    use HasResourceKeyTrait;
 
 }

--- a/docs/_docs/getting-started/responses.md
+++ b/docs/_docs/getting-started/responses.md
@@ -98,9 +98,19 @@ API_RESPONSE_SERIALIZER=League\Fractal\Serializer\DataArraySerializer
 
 The Supported Serializers are (`ArraySerializer`, `DataArraySerializer` and `JsonApiSerializer`).
 
+The `JsonApiSerializer` provides the possibility to append a `ResourceKey` for the transformed resource. There are a 
+few ways to set this key (used in this order by the framework):
 
-More details at [Fractal](http://fractal.thephpleague.com/transformers/) and [Laravel Fractal Wrapper](https://github.com/spatie/laravel-fractal).
+1) You can manually set it via the respective parameter in the `$this->transform()` call. Note that this will only set the 
+`top level` resource key and does not affect the resource keys from `included` resources!
+2) If you do not define the key in the `$this->transform` method, you can specify it on the respective `Model`. You can simply
+override the the `protected $resourceKey = 'FooBar';` in order to specify the latter.
+3) If no `$resourceKey` is defined at the `Model`, the `ShortClassName` is used as key. For example, the `ShortClassName` of 
+the `App\Containers\User\Models\User::class` is `User`.
 
+More details can be found at [Fractal](http://fractal.thephpleague.com/transformers/) and [Laravel Fractal Wrapper](https://github.com/spatie/laravel-fractal).
+
+# Building a Responses from the Controller:
 
 ## Building a Responses from the Controller:
 


### PR DESCRIPTION
This adds the functionality to add the JSON API Resource Key to a Response.

Please also see the PR in the `apiato/core` package here https://github.com/apiato/core/pull/1