### PR TITLE
bump laravel-permission version to latest 1.x version

### DIFF
--- a/app/Containers/Authorization/composer.json
+++ b/app/Containers/Authorization/composer.json
@@ -2,6 +2,6 @@
   "name": "apiato/authorization",
   "description": "apiato Container.",
   "require": {
-    "spatie/laravel-permission": "1.9.*"
+    "spatie/laravel-permission": "^1.12"
   }
 }


### PR DESCRIPTION
this updates to the latest 1.x version of the laravel-permission package.
Tests still pass..

Keep in mind, that this package is now in 2.4.x version available. However, a migration from 1.x to 2.x is not easily possible.. Maybe the `Authorization` container needs to be rebuild from scratch!?