### PR TITLE
Add reminder to create .env in laradock folder

### DIFF
--- a/docs/_docs/getting-started/installation.md
+++ b/docs/_docs/getting-started/installation.md
@@ -46,6 +46,12 @@ cd laradock
 ```
 This directory contains a `docker-compose.yml` file. (From the LaraDock project).
 
+2.1) If you haven't done so, rename `env-example` to `.env`.
+
+```shell
+cp env-example .env
+```
+
 3) Run the Docker containers:
 
 ```shell


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A reminder to create `.env` in laradock folder in case it was skipped or forgotten during laradock installation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve, or what feature does it add? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I had errors when I installed apiato the first time, and took me a while to realize that it was caused by not having `.env` file.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. (PHPUnit is the highly recommended way) -->
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We'd love to help! -->
- [x] My code follows the code style and structure of this project.
- [x] I have updated the documentation accordingly.
