### PR TITLE
fix auto-discovery issue

### DIFF
--- a/app/Containers/Authorization/Configs/permission.php
+++ b/app/Containers/Authorization/Configs/permission.php
@@ -1,7 +1,9 @@
 <?php
 
 return [
+
     'models' => [
+
         /*
          * When using the "HasRoles" trait from this package, we need to know which
          * Eloquent model should be used to retrieve your permissions. Of course, it
@@ -11,6 +13,7 @@ return [
          * `Spatie\Permission\Contracts\Permission` contract.
          */
         'permission' => App\Containers\Authorization\Models\Permission::class, // Spatie\Permission\Models\Permission::class
+
         /*
          * When using the "HasRoles" trait from this package, we need to know which
          * Eloquent model should be used to retrieve your roles. Of course, it
@@ -21,31 +24,37 @@ return [
          */
         'role' => App\Containers\Authorization\Models\Role::class, //Spatie\Permission\Models\Role::class
     ],
+
     'table_names' => [
+
         /*
          * When using the "HasRoles" trait from this package, we need to know which
          * table should be used to retrieve your roles. We have chosen a basic
          * default value but you may easily change it to any table you like.
          */
         'roles' => 'roles',
+
         /*
          * When using the "HasRoles" trait from this package, we need to know which
          * table should be used to retrieve your permissions. We have chosen a basic
          * default value but you may easily change it to any table you like.
          */
         'permissions' => 'permissions',
+
         /*
          * When using the "HasRoles" trait from this package, we need to know which
          * table should be used to retrieve your models permissions. We have chosen a
          * basic default value but you may easily change it to any table you like.
          */
         'model_has_permissions' => 'model_has_permissions',
+
         /*
          * When using the "HasRoles" trait from this package, we need to know which
          * table should be used to retrieve your models roles. We have chosen a
          * basic default value but you may easily change it to any table you like.
          */
         'model_has_roles' => 'model_has_roles',
+
         /*
          * When using the "HasRoles" trait from this package, we need to know which
          * table should be used to retrieve your roles permissions. We have chosen a
@@ -53,11 +62,13 @@ return [
          */
         'role_has_permissions' => 'role_has_permissions',
     ],
+
     /*
      * By default all permissions will be cached for 24 hours unless a permission or
      * role is updated. Then the cache will be flushed immediately.
      */
     'cache_expiration_time' => 60 * 24,
+
     /*
      * By default we'll make an entry in the application log when the permissions
      * could not be loaded. Normally this only occurs while installing the packages.

--- a/app/Ship/Configs/fractal.php
+++ b/app/Ship/Configs/fractal.php
@@ -1,31 +1,41 @@
 <?php
+
 return [
+
     /*
      * The default serializer to be used when performing a transformation. It
      * may be left empty to use Fractal's default one. This can either be a
      * string or a League\Fractal\Serializer\SerializerAbstract subclass.
      */
     'default_serializer' => env('API_RESPONSE_SERIALIZER', 'League\Fractal\Serializer\DataArraySerializer'),
-    /* The default paginator to be used when performing a transformation. It
+
+    /*
+     * The default paginator to be used when performing a transformation. It
      * may be left empty to use Fractal's default one. This can either be a
-     * string or a League\Fractal\Paginator\PaginatorInterface subclass.*/
+     * string or a League\Fractal\Paginator\PaginatorInterface subclass.*
+     */
     'default_paginator' => '',
+
     /*
      * League\Fractal\Serializer\JsonApiSerializer will use this value to
      * as a prefix for generated links. Set to `null` to disable this.
      */
     'base_url' => null,
+
     /*
      * If you wish to override or extend the default Spatie\Fractal\Fractal
      * instance provide the name of the class you want to use.
      */
     'fractal_class' => Spatie\Fractal\Fractal::class,
+
     'auto_includes' => [
+
         /*
          * If enabled Fractal will automatically add the includes who's
          * names are present in the `include` request parameter.
          */
         'enabled' => true,
+
         /*
          * The name of key in the request to where we should look for the includes to include.
          */

--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,7 @@
   "extra": {
     "laravel": {
       "dont-discover": [
+        "*"
       ]
     },
     "merge-plugin": {

--- a/docs/_docs/components/providers.md
+++ b/docs/_docs/components/providers.md
@@ -38,6 +38,10 @@ They are the place where you register things like container bindings, event list
 
 - You should not register any Provider in the framework (`config/app.php`), only the `ApiatoProvider` should be registered there.
 
+> **Important Information**: Laravel 5.5 introduces an `auto-discovery` feature that lets you automatically register `ServiceProviders`. 
+Due to the nature and structure of APIATO applications, this features **is turned off**, because it messes up how `config` files are loaded 
+in apiato. This means, that you still need to **manually** register 3rd-party `ServiceProviders` in the `ServiceProvider` of a `Container`.
+
 ### Folder Structure
 
 **Example: User Container `Service Providers`** 

--- a/docs/_docs/miscellaneous/faq.md
+++ b/docs/_docs/miscellaneous/faq.md
@@ -14,6 +14,7 @@ order: 5
 * [How to enable Query Caching?](#q8)
 * [Can I give my Actions REST names?](#q9)
 * [How Service Providers are auto-loaded?](#q11)
+* [I would like to use Laravel's awesome Auto-Discovery Feature, but it does not work!](#q12)
 * [I have a question and I can't find answer!!](#q100)
 
 <br>
@@ -91,6 +92,9 @@ However, some more general Service Providers and Aliases (application features u
 
 Refer to the [Providers]({{ site.baseurl }}{% link _docs/components/providers.md %}) page for more details.
 
+> **Important Information**: Laravel 5.5 introduces an `auto-discovery` feature that lets you automatically register `ServiceProviders`. 
+Due to the nature and structure of APIATO applications, this features **is turned off**, because it messes up how `config` files are loaded 
+in apiato. This means, that you still need to **manually** register 3rd-party `ServiceProviders` in the `ServiceProvider` of a `Container`.
 
 <a name="q5"></a>
 ## How to change the default API URL (Subdomain and Prefix)?
@@ -162,8 +166,6 @@ one “similar to TDD/BDD” with the help of a command that tells what you alre
 needs to be completed.. as well as what Tasks are available to be used from any Action..
 
 
-
-
 <a name="q11"></a>
 ## How Service Providers are auto-loaded?
 
@@ -173,18 +175,25 @@ When `runLoadersBoot()` is called it auto register all the Main Providers from a
 Each main provider calls its`boot()` function after being registered, which calls `loadServiceProviders()` to register all the other container Providers. 
 The other providers must be defined on its `$serviceProviders` property, otherwise will be ignored.
 
-
 On the other side the `ApiatoServiceProvider` is manually registered on the `app.php` file (and it's the only one registered there). 
 
 The `ApiatoServiceProvider` is the one who calls the `runLoadersBoot()`, on startup. 
 After he call that function he registers the Ship Providers which has all the other Ship Providers defined on its `$serviceProviders` property.
 
+> **Important Information**: Laravel 5.5 introduces an `auto-discovery` feature that lets you automatically register `ServiceProviders`. 
+Due to the nature and structure of APIATO applications, this features **is turned off**, because it messes up how `config` files are loaded 
+in apiato. This means, that you still need to **manually** register 3rd-party `ServiceProviders` in the `ServiceProvider` of a `Container`.
 
 
+<a name="q11"></a>
+## I would like to use Laravel's awesome Auto-Discovery Feature, but it does not work!
 
+That is, because this feature is turned off by default in APIATO. The Laravel `Auto-Discovery` feature registers 3rd-party 
+Service Providers during startup of the application and thereby messes with the way, APIATO handles / loads components. 
+This is especially in the context of `config` files problematic, as they are ignored.
 
-
-
+> You **must** register 3rd-party Service Providers on your own in the `MainServiceProvider` of respective Container 
+(i.e., how you did it always before Laravel 5.4!)
 
 
 

--- a/docs/_docs/miscellaneous/upgrade-guide.md
+++ b/docs/_docs/miscellaneous/upgrade-guide.md
@@ -18,7 +18,9 @@ Note: Some of the files are not required to be upgraded. And some of them, can b
 
 Hint: You can do a git merge and solve the conflicts, if you don't want to manually do the changes commit by commit.
 
-
+> **Important Information**: Laravel 5.5 introduces an `auto-discovery` feature that lets you automatically register `ServiceProviders`. 
+Due to the nature and structure of APIATO applications, this features **is turned off**, because it messes up how `config` files are loaded 
+in apiato. This means, that you still need to **manually** register 3rd-party `ServiceProviders` in the `ServiceProvider` of a `Container`.
 
 ## Upgrade Apiato from version 4.1 to 5.0:
 


### PR DESCRIPTION
Fixes the problem with `config` files not being correctly loaded! This is caused by laravels newly introduced `Auto-Discovery` feature..

Basically, this PR turns `AD` off (i.e., it marks all packages to be not discovered any more).

Minor:
- moved `fractal.php` config file to `Ship/Configs`
- moved `permission.php` config file to `Containers/Authorization`
- updated docs to reflect the changes to auto-discovery
- formatting config files