### PR TITLE
add (optional) "ETag Middleware"

### DIFF
--- a/app/Ship/Configs/apiato.php
+++ b/app/Ship/Configs/apiato.php
@@ -133,6 +133,20 @@ return [
         |
         */
         'force-accept-header' => false,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Use ETags
+        |--------------------------------------------------------------------------
+        |
+        | This option appends an "ETag" HTTP Header to the Response. This ETag is a
+        | calculated hash of the content to be delivered.
+        | Clients can add an "If-None-Match" HTTP Header to the Request and submit
+        | an (old) ETag. These ETags are validated. If they match (are the same),
+        | an empty BODY with HTTP STATUS 304 (not modified) ist returned!
+        |
+        */
+        'use-etag' => false,
     ],
 
 ];

--- a/app/Ship/Kernels/HttpKernel.php
+++ b/app/Ship/Kernels/HttpKernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Ship\Kernels;
 
+use App\Ship\Middlewares\Http\ProcessETagHeadersMiddleware;
 use App\Ship\Middlewares\Http\ValidateJsonContent;
 use Illuminate\Foundation\Http\Kernel as LaravelHttpKernel;
 
@@ -53,6 +54,7 @@ class HttpKernel extends LaravelHttpKernel
         'api' => [
             ValidateJsonContent::class,
             'bindings',
+            ProcessETagHeadersMiddleware::class,
             // The throttle Middleware is registered by the RoutesLoaderTrait in the Core
         ],
     ];

--- a/app/Ship/Middlewares/Http/ProcessETagHeadersMiddleware.php
+++ b/app/Ship/Middlewares/Http/ProcessETagHeadersMiddleware.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Ship\Middlewares\Http;
+
+use App;
+use App\Ship\Parents\Middlewares\Middleware;
+use Closure;
+use Config;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpKernel\Exception\PreconditionFailedHttpException;
+
+/**
+ * Class ProcessETagHeadersMiddleware
+ *
+ * @author  Johannes Schobel <johannes.schobel@googlemail.com>
+ */
+class ProcessETagHeadersMiddleware extends Middleware
+{
+
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure                 $next
+     *
+     * @return mixed
+     * @throws PreconditionFailedHttpException
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        /*
+         * This middleware will add the "ETag" HTTP Header to a Response. The ETag, in turn, is a
+         * hash of the content that will be returned. The client may request an endpoint and provide an ETag in the
+         * "If-None-Match" HTTP Header. If the calculated ETag and submitted ETag matches, the response is manipulated
+         * accordingly:
+         * - the HTTP Status Code is set to 304 (not modified)
+         * - the body content (i.e., the content that was supposed to be delivered) is removed --> the client receives an empty body
+         */
+
+        // the feature is disabled - so skip everything
+        if (config('apiato.requests.use-etag', false) === false) {
+            return $next($request);
+        }
+
+
+        // check, if an "if-none-match" header is supplied
+        if ($request->hasHeader('if-none-match')) {
+            // check, if the request method is GET or HEAD
+            if ( ! ($request->method() == 'GET' || $request->method() == 'HEAD')) {
+                throw new PreconditionFailedHttpException('HTTP Header IF-None-Match is only allowed for GET and HEAD Requests.');
+            }
+        }
+
+        // everything is fine, just call the next middleware. We will process the ETag later on..
+        $response = $next($request);
+
+        // now we have processed the request and have a response that is sent back to the client.
+        // calculate the etag of the content!
+        $content = $response->getContent();
+        $etag = md5($content);
+        $response->headers->set('Etag', $etag);
+
+        // now, lets check, if the request contains a "if-none-match" http header field
+        if ($request->hasHeader('if-none-match')) {
+            // now check, if the if-none-match etag is the same as the calculated etag!
+            if ($request->header('if-none-match') == $etag) {
+                $response->setStatusCode(304);
+            }
+        }
+
+        return $response;
+    }
+
+}

--- a/docs/_docs/getting-started/requests.md
+++ b/docs/_docs/getting-started/requests.md
@@ -9,17 +9,15 @@ order: 5
 Certain API calls require you to send data in a particular format as part of the API call. 
 By default, all API calls expect input in `JSON` format, however you need to inform the server that you are sending a JSON-formatted payload.
 
-
-
 | Header        | Value Sample                        | When to send it                                                              |
 |---------------|-------------------------------------|------------------------------------------------------------------------------|
 | Accept        | `application/json`                  | MUST be sent with every endpoint.                                            |
 | Content-Type  | `application/x-www-form-urlencoded` | MUST be sent when passing Data.                                              |
 | Authorization | `Bearer {Access-Token-Here}`        | MUST be sent whenever the endpoint requires (Authenticated User).            |
+| If-None-Match | `811b22676b6a4a0489c920073c0df914`  | MAY be sent to indicate a specific **ETag** of an prior Request to this Endpoint. If both ETags match (i.e., are the same) a HTTP 304 (not modified) is returned. |
 
 
-### 
-Normally you should include the `Accept => application/json` HTTP header when you call a JOSN API.
+> Normally you should include the `Accept => application/json` HTTP header when you call a JOSN API.
 However, in Apiato you can force your users to send `application/json` by setting `'force-accept-header' => true,` in `app/Ship/Configs/apiato.php` 
 Or allow them to skip it by setting the `'force-accept-header' => false,` (By default this is set to false).
 


### PR DESCRIPTION
This PR adds an (optional) ETag Middleware.

This middleware appends an `ETag` HTTP Header field with a hash of the response body. If a client sends an `If-None-Match` HTTP Header with an ETag, this ETag is compared with the calculated one.

If those ETags match, the content has not changed --> The response is discarded (empty body) and an HTTP 304 (not modified) is returned.

Can be enabled/disabled (default = disabled) in `App/Ship/Configs/apiato.php` file