### PR TITLE
Add "names" (as) to Routes

### DIFF
--- a/app/Containers/Authentication/UI/API/Routes/Logout.v1.public.php
+++ b/app/Containers/Authentication/UI/API/Routes/Logout.v1.public.php
@@ -15,6 +15,7 @@
 }
  */
 $router->post('logout', [
+    'as' => 'API_Authentication_Logout',
     'uses'  => 'Controller@logout',
     'middleware' => [
         'auth:api',

--- a/app/Containers/Authentication/UI/API/Routes/ProxyLoginForAdminWebClient.v1.public.php
+++ b/app/Containers/Authentication/UI/API/Routes/ProxyLoginForAdminWebClient.v1.public.php
@@ -21,5 +21,6 @@
 }
  */
 $router->post('clients/web/admin/login', [
+    'as' => 'API_Authentication_ClientAdminWebAppLoginProxy',
     'uses'  => 'Controller@proxyLoginForAdminWebClient',
 ]);

--- a/app/Containers/Authentication/UI/API/Routes/ProxyRefreshForAdminWebClient.v1.public.php
+++ b/app/Containers/Authentication/UI/API/Routes/ProxyRefreshForAdminWebClient.v1.public.php
@@ -20,5 +20,6 @@
 }
  */
 $router->post('clients/web/admin/refresh', [
+    'as' => 'API_Authentication_ClientAdminWebAppRefreshProxy',
     'uses'  => 'Controller@proxyRefreshForAdminWebClient',
 ]);

--- a/app/Containers/Authorization/UI/API/Routes/AssignUserToRole.v1.private.php
+++ b/app/Containers/Authorization/UI/API/Routes/AssignUserToRole.v1.private.php
@@ -20,6 +20,7 @@
  */
 
 $router->post('roles/assign', [
+    'as' => 'API_Authorization_assignUserToRole',
     'uses'       => 'Controller@assignUserToRole',
     'middleware' => [
         'auth:api',

--- a/app/Containers/Authorization/UI/API/Routes/AttachPermissionToRole.v1.private.php
+++ b/app/Containers/Authorization/UI/API/Routes/AttachPermissionToRole.v1.private.php
@@ -20,6 +20,7 @@
  */
 
 $router->post('permissions/attach', [
+    'as' => 'API_Authorization_attachPermissionToRole',
     'uses'       => 'Controller@attachPermissionToRole',
     'middleware' => [
         'auth:api',

--- a/app/Containers/Authorization/UI/API/Routes/CreateRole.v1.private.php
+++ b/app/Containers/Authorization/UI/API/Routes/CreateRole.v1.private.php
@@ -16,6 +16,7 @@
  */
 
 $router->post('roles', [
+    'as' => 'API_Authorization_createRole',
     'uses'       => 'Controller@createRole',
     'middleware' => [
         'auth:api',

--- a/app/Containers/Authorization/UI/API/Routes/DeleteRole.v1.private.php
+++ b/app/Containers/Authorization/UI/API/Routes/DeleteRole.v1.private.php
@@ -17,6 +17,7 @@
  */
 
 $router->delete('roles/{id}', [
+    'as' => 'API_Authorization_deleteRole',
     'uses'       => 'Controller@deleteRole',
     'middleware' => [
         'auth:api',

--- a/app/Containers/Authorization/UI/API/Routes/DetachPermissionsFromRole.v1.private.php
+++ b/app/Containers/Authorization/UI/API/Routes/DetachPermissionsFromRole.v1.private.php
@@ -20,6 +20,7 @@
  */
 
 $router->post('permissions/detach', [
+    'as' => 'API_Authorization_detachPermissionFromRole',
     'uses'       => 'Controller@detachPermissionFromRole',
     'middleware' => [
         'auth:api',

--- a/app/Containers/Authorization/UI/API/Routes/FindPermission.v1.private.php
+++ b/app/Containers/Authorization/UI/API/Routes/FindPermission.v1.private.php
@@ -12,6 +12,7 @@
  */
 
 $router->get('permissions/{id}', [
+    'as' => 'API_Authorization_getPermission',
     'uses'       => 'Controller@getPermission',
     'middleware' => [
         'auth:api',

--- a/app/Containers/Authorization/UI/API/Routes/FindRole.v1.private.php
+++ b/app/Containers/Authorization/UI/API/Routes/FindRole.v1.private.php
@@ -12,6 +12,7 @@
  */
 
 $router->get('roles/{id}', [
+    'as' => 'API_Authorization_getRole',
     'uses'       => 'Controller@getRole',
     'middleware' => [
         'auth:api',

--- a/app/Containers/Authorization/UI/API/Routes/ListAllPermissions.v1.private.php
+++ b/app/Containers/Authorization/UI/API/Routes/ListAllPermissions.v1.private.php
@@ -12,6 +12,7 @@
  */
 
 $router->get('permissions', [
+    'as' => 'API_Authorization_listAllPermissions',
     'uses'       => 'Controller@listAllPermissions',
     'middleware' => [
         'auth:api',

--- a/app/Containers/Authorization/UI/API/Routes/ListAllRoles.v1.private.php
+++ b/app/Containers/Authorization/UI/API/Routes/ListAllRoles.v1.private.php
@@ -12,6 +12,7 @@
  */
 
 $router->get('roles', [
+    'as' => 'API_Authorization_listAllRoles',
     'uses'       => 'Controller@listAllRoles',
     'middleware' => [
         'auth:api',

--- a/app/Containers/Authorization/UI/API/Routes/RevokeUserFromRole.v1.private.php
+++ b/app/Containers/Authorization/UI/API/Routes/RevokeUserFromRole.v1.private.php
@@ -20,6 +20,7 @@
  */
 
 $router->post('roles/revoke', [
+    'as' => 'API_Authorization_revokeRoleFromUser',
     'uses'       => 'Controller@revokeRoleFromUser',
     'middleware' => [
         'auth:api',

--- a/app/Containers/Authorization/UI/API/Routes/SyncPermissionOnRole.v1.private.php
+++ b/app/Containers/Authorization/UI/API/Routes/SyncPermissionOnRole.v1.private.php
@@ -17,6 +17,7 @@
  */
 
 $router->post('permissions/sync', [
+    'as' => 'API_Authorization_syncPermissionOnRole',
     'uses'       => 'Controller@syncPermissionOnRole',
     'middleware' => [
         'auth:api',

--- a/app/Containers/Authorization/UI/API/Routes/SyncUserRoles.v1.private.php
+++ b/app/Containers/Authorization/UI/API/Routes/SyncUserRoles.v1.private.php
@@ -18,6 +18,7 @@
  */
 
 $router->post('roles/sync', [
+    'as' => 'API_Authorization_syncUserRoles',
     'uses'       => 'Controller@syncUserRoles',
     'middleware' => [
         'auth:api',

--- a/app/Containers/Settings/UI/API/Routes/CreateSetting.v1.private.php
+++ b/app/Containers/Settings/UI/API/Routes/CreateSetting.v1.private.php
@@ -29,6 +29,7 @@
  */
 
 $router->post('settings', [
+    'as' => 'API_Settings_createSetting',
     'uses'  => 'Controller@createSetting',
     'middleware' => [
       'auth:api',

--- a/app/Containers/Settings/UI/API/Routes/DeleteSetting.v1.private.php
+++ b/app/Containers/Settings/UI/API/Routes/DeleteSetting.v1.private.php
@@ -19,6 +19,7 @@
  */
 
 $router->delete('settings/{id}', [
+    'as' => 'API_Settings_deleteSetting',
     'uses'  => 'Controller@deleteSetting',
     'middleware' => [
       'auth:api',

--- a/app/Containers/Settings/UI/API/Routes/ListAllSettings.v1.private.php
+++ b/app/Containers/Settings/UI/API/Routes/ListAllSettings.v1.private.php
@@ -42,6 +42,7 @@
  */
 
 $router->get('settings', [
+    'as' => 'API_Settings_listAllSettings',
     'uses'  => 'Controller@listAllSettings',
     'middleware' => [
       'auth:api',

--- a/app/Containers/Settings/UI/API/Routes/UpdateSetting.v1.private.php
+++ b/app/Containers/Settings/UI/API/Routes/UpdateSetting.v1.private.php
@@ -29,6 +29,7 @@
  */
 
 $router->patch('settings/{id}', [
+    'as' => 'API_Settings_updateSetting',
     'uses'  => 'Controller@updateSetting',
     'middleware' => [
       'auth:api',

--- a/app/Containers/Socialauth/UI/API/Routes/AuthenticateAll.v1.private.php
+++ b/app/Containers/Socialauth/UI/API/Routes/AuthenticateAll.v1.private.php
@@ -123,5 +123,6 @@ HTTP/1.1 200 OK
 }
  */
 $router->post('auth/{provider}', [
+    'as' => 'API_Socialauth_socialAuth',
     'uses' => 'Controller@authenticateAll',
 ]);

--- a/app/Containers/Socialauth/UI/WEB/Routes/GetProvider.php
+++ b/app/Containers/Socialauth/UI/WEB/Routes/GetProvider.php
@@ -1,0 +1,7 @@
+<?php
+
+// provider login redirect (WEB)
+$router->get('auth/{provider}', [
+    'as' => 'WEB_Socialauth_redirect',
+    'uses' => 'Controller@redirectAll',
+]);

--- a/app/Containers/Socialauth/UI/WEB/Routes/ProviderCallback.php
+++ b/app/Containers/Socialauth/UI/WEB/Routes/ProviderCallback.php
@@ -1,12 +1,8 @@
 <?php
 
-// provider login redirect (WEB)
-$router->get('auth/{provider}', [
-    'uses' => 'Controller@redirectAll',
-]);
-
 // provider callback handler
 $router->any('auth/{provider}/callback', [
+    'as' => 'WEB_Socialauth_callback',
     'uses' => 'Controller@handleCallbackAll',
 ]);
 

--- a/app/Containers/Stripe/UI/API/Routes/CreateStripeAccount.v1.private.php
+++ b/app/Containers/Stripe/UI/API/Routes/CreateStripeAccount.v1.private.php
@@ -26,6 +26,7 @@
  */
 
 $router->post('/stripes', [
+    'as' => 'API_Stripe_createStripeAccount',
     'uses' => 'Controller@createStripeAccount',
     'middleware' => [
         'auth:api',

--- a/app/Containers/User/UI/API/Routes/CreateAdmin.v1.private.php
+++ b/app/Containers/User/UI/API/Routes/CreateAdmin.v1.private.php
@@ -2,7 +2,7 @@
 
 /**
  * @apiGroup           Users
- * @apiName            CreateAdmin
+ * @apiName            createAdmin
  * @api                {post} /v1/admins Create Admin type Users
  * @apiDescription     Creating non client Users, form the Dashboard.
  *
@@ -17,6 +17,7 @@
  */
 
 $router->post('admins', [
+    'as' => 'API_User_createAdmin',
     'uses'  => 'Controller@createAdmin',
     'middleware' => [
         'auth:api',

--- a/app/Containers/User/UI/API/Routes/DeleteUser.v1.private.php
+++ b/app/Containers/User/UI/API/Routes/DeleteUser.v1.private.php
@@ -2,7 +2,7 @@
 
 /**
  * @apiGroup           Users
- * @apiName            DeleteUser
+ * @apiName            deleteUser
  * @api                {delete} /v1/users/:id Delete User (admin, client..)
  * @apiDescription     Delete Users of any type (Admin, Client,...)
  *
@@ -17,6 +17,7 @@
  */
 
 $router->delete('users/{id}', [
+    'as' => 'API_User_deleteUser',
     'uses'       => 'Controller@deleteUser',
     'middleware' => [
         'auth:api',

--- a/app/Containers/User/UI/API/Routes/GetUser.v1.private.php
+++ b/app/Containers/User/UI/API/Routes/GetUser.v1.private.php
@@ -13,6 +13,7 @@
  */
 
 $router->get('users/{id}', [
+    'as' => 'API_User_getUser',
     'uses'       => 'Controller@getUser',
     'middleware' => [
         'auth:api',

--- a/app/Containers/User/UI/API/Routes/GetUserProfile.v1.private.php
+++ b/app/Containers/User/UI/API/Routes/GetUserProfile.v1.private.php
@@ -16,6 +16,7 @@
  */
 
 $router->get('user/profile', [
+    'as' => 'API_User_getUserProfile',
     'uses'  => 'Controller@getUserProfile',
     'middleware' => [
       'auth:api',

--- a/app/Containers/User/UI/API/Routes/ListAllAdmins.v1.private.php
+++ b/app/Containers/User/UI/API/Routes/ListAllAdmins.v1.private.php
@@ -2,7 +2,7 @@
 
 /**
  * @apiGroup           Users
- * @apiName            ListAllAdmins
+ * @apiName            listAllAdmins
  * @api                {get} /v1/admins List Admin Users
  * @apiDescription     List all Users where role `Admin`.
  *                     You can search for Users by email, name and ID.
@@ -17,6 +17,7 @@
  */
 
 $router->get('admins', [
+    'as' => 'API_User_listAllAdmins',
     'uses'       => 'Controller@listAllAdmins',
     'middleware' => [
         'auth:api',

--- a/app/Containers/User/UI/API/Routes/ListAllClients.v1.private.php
+++ b/app/Containers/User/UI/API/Routes/ListAllClients.v1.private.php
@@ -2,7 +2,7 @@
 
 /**
  * @apiGroup           Users
- * @apiName            ListAllClients
+ * @apiName            listAllClients
  * @api                {get} /v1/clients List Client Users
  * @apiDescription     List all Users where role `Client`.
  *                     You can search for Users by email, name and ID.
@@ -17,6 +17,7 @@
  */
 
 $router->get('clients', [
+    'as' => 'API_User_listAllClients',
     'uses'       => 'Controller@listAllClients',
     'middleware' => [
         'auth:api',

--- a/app/Containers/User/UI/API/Routes/ListAllUsers.v1.private.php
+++ b/app/Containers/User/UI/API/Routes/ListAllUsers.v1.private.php
@@ -2,7 +2,7 @@
 
 /**
  * @apiGroup           Users
- * @apiName            ListAllUsers
+ * @apiName            listAllUsers
  * @api                {get} /v1/users List All Users
  * @apiDescription     List all Application Users (clients and admins). For all registered users "Clients" only you
  *                     can use `/clients`. And for all "Admins" only you can use `/admins`.
@@ -14,6 +14,7 @@
  */
 
 $router->get('users', [
+    'as' => 'API_User_listAllUsers',
     'uses'       => 'Controller@listAllUsers',
     'middleware' => [
         'auth:api',

--- a/app/Containers/User/UI/API/Routes/RegisterUser.v1.private.php
+++ b/app/Containers/User/UI/API/Routes/RegisterUser.v1.private.php
@@ -19,5 +19,6 @@
  */
 
 $router->post('/register', [
+    'as' => 'API_User_registerUser',
     'uses'  => 'Controller@registerUser',
 ]);

--- a/app/Containers/User/UI/API/Routes/UpdateUser.v1.private.php
+++ b/app/Containers/User/UI/API/Routes/UpdateUser.v1.private.php
@@ -2,7 +2,7 @@
 
 /**
  * @apiGroup           Users
- * @apiName            UpdateUser
+ * @apiName            updateUser
  * @api                {put} /v1/users/:id Update User
  *
  * @apiVersion         1.0.0
@@ -15,6 +15,7 @@
  */
 
 $router->put('users/{id}', [
+    'as' => 'API_User_updateUser',
     'uses'       => 'Controller@updateUser',
     'middleware' => [
         'auth:api',

--- a/app/Containers/Wepay/UI/API/Routes/CreateWepayAccount.v1.private.php
+++ b/app/Containers/Wepay/UI/API/Routes/CreateWepayAccount.v1.private.php
@@ -2,7 +2,7 @@
 
 /**
  * @apiGroup           wepay
- * @apiName            createwepayAccount
+ * @apiName            createWepayAccount
  * @api                {post} /v1/wepays Create wepay Account
  * @apiDescription     Before calling this endpoint make sure to call wepay first and get the `customer_id`.
  *                     You may use "Wepay Checkout" or "wepay.js" to make your Wepay call. This Information
@@ -20,6 +20,7 @@
  */
 
 $router->post('/wepays', [
+    'as' => 'API_Wepay_createWepayAccount',
     'uses' => 'Controller@createWepayAccount',
     'middleware' => [
         'auth:api',


### PR DESCRIPTION
This PR adds the "as" param to existing Routes from the default apiato project.

Note that routes, that already had an `as` param, where **not** adjusted to the new name-schema. However, if you like, i can make this.. Would be better, i think.. What is your opinion on this!?

This PR is initially triggered by [thisPR here](https://github.com/apiato/core/pull/8)

Cheers