### PR TITLE
Better Exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Add new Facade class `Apiato` containing the old Butlers classes functions, in addition to the `call` magical methode (`Apiato::call()`) in the `CallableTrait`.
 - Add container specific config file to each container.
 - Add readme.md file to each container.
+- Add possibility to `customize` the way, `Exceptions` are displayed (cf. `ExceptionFormatters`)
 
 ### Changed
 - Upgrade Mail to use Laravel 5.5 Mails. And add Ship directory for Mail in addition to user mail sample in the User container.
@@ -48,6 +49,7 @@
 - Renamed `wepay.php` config file to `wepay-container.php`.
 - Rename `ListAll` to `GetAll` in every Actions/Tasks/controller functions/route files/requests
 - Rename `Get` to `Find` in every Actions/Tasks/controller functions/route files/requests
+- Slight adaptations to the `Exception` message format (due to `ExceptionFormatters`)
 
 ### Fixed
 - Fix Social Authentication errors. 

--- a/app/Containers/User/UI/API/Tests/Functional/RegisterUserTest.php
+++ b/app/Containers/User/UI/API/Tests/Functional/RegisterUserTest.php
@@ -63,7 +63,7 @@ class RegisterUserTest extends TestCase
         $response->assertStatus(405);
 
         $this->assertResponseContainKeyValue([
-            'errors' => '405 Method Not Allowed.',
+            'errors' => 'Method Not Allowed!',
         ]);
     }
 

--- a/app/Containers/User/UI/API/Tests/Functional/UpdateUserTest.php
+++ b/app/Containers/User/UI/API/Tests/Functional/UpdateUserTest.php
@@ -60,7 +60,7 @@ class UpdateUserTest extends TestCase
         $response->assertStatus(400);
 
         $this->assertResponseContainKeyValue([
-            'errors' => 'Oops something went wrong.'
+            'status' => 'error'
         ]);
     }
 

--- a/app/Ship/Configs/optimus.heimdal.php
+++ b/app/Ship/Configs/optimus.heimdal.php
@@ -7,13 +7,15 @@ return [
 
     // Has to be in prioritized order, e.g. highest priority first.
     'formatters' => [
-
         // insert your custom Exception Formatters here!
 
 
         // Apiato Exception Formatters below
         \Illuminate\Validation\ValidationException::class => \App\Ship\Exceptions\Formatters\ValidationExceptionFormatter::class,
         SymfonyException\UnprocessableEntityHttpException::class => \App\Ship\Exceptions\Formatters\UnprocessableEntityHttpExceptionFormatter::class,
+        Illuminate\Auth\AuthenticationException::class => \App\Ship\Exceptions\Formatters\AuthenticationExceptionFormatter::class,
+        Illuminate\Auth\Access\AuthorizationException::class => \App\Ship\Exceptions\Formatters\AuthorizationExceptionFormatter::class,
+        SymfonyException\MethodNotAllowedHttpException::class => \App\Ship\Exceptions\Formatters\MethodNotAllowedExceptionFormatter::class,
         SymfonyException\HttpException::class => \App\Ship\Exceptions\Formatters\HttpExceptionFormatter::class,
         Exception::class => \App\Ship\Exceptions\Formatters\ExceptionFormatter::class,
     ],

--- a/app/Ship/Configs/optimus.heimdal.php
+++ b/app/Ship/Configs/optimus.heimdal.php
@@ -1,0 +1,36 @@
+<?php
+
+use Symfony\Component\HttpKernel\Exception as SymfonyException;
+
+return [
+    'add_cors_headers' => false,
+
+    // Has to be in prioritized order, e.g. highest priority first.
+    'formatters' => [
+
+        // insert your custom Exception Formatters here!
+
+
+        // Apiato Exception Formatters below
+        \Illuminate\Validation\ValidationException::class => \App\Ship\Exceptions\Formatters\ValidationExceptionFormatter::class,
+        SymfonyException\UnprocessableEntityHttpException::class => \App\Ship\Exceptions\Formatters\UnprocessableEntityHttpExceptionFormatter::class,
+        SymfonyException\HttpException::class => \App\Ship\Exceptions\Formatters\HttpExceptionFormatter::class,
+        Exception::class => \App\Ship\Exceptions\Formatters\ExceptionFormatter::class,
+    ],
+
+    'response_factory' => \App\Ship\Exceptions\Builders\ExceptionBuilder::class,
+
+    'reporters' => [
+        /*'sentry' => [
+            'class'  => \Optimus\Heimdal\Reporters\SentryReporter::class,
+            'config' => [
+                'dsn' => '',
+                // For extra options see https://docs.sentry.io/clients/php/config/
+                // php version and environment are automatically added.
+                'sentry_options' => []
+            ]
+        ]*/
+    ],
+
+    'server_error_production' => 'An error occurred.'
+];

--- a/app/Ship/Exceptions/Builders/ExceptionBuilder.php
+++ b/app/Ship/Exceptions/Builders/ExceptionBuilder.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Ship\Exceptions\Builders;
+
+use Apiato\Core\Abstracts\Exceptions\Builders\BaseExceptionBuilder;
+use Exception;
+use Illuminate\Http\JsonResponse;
+
+class ExceptionBuilder extends BaseExceptionBuilder
+{
+    public static function make(Exception $e)
+    {
+        return new JsonResponse([
+            'status' => 'error',
+        ]);
+    }
+}

--- a/app/Ship/Exceptions/Formatters/AuthenticationExceptionFormatter.php
+++ b/app/Ship/Exceptions/Formatters/AuthenticationExceptionFormatter.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Ship\Exceptions\Formatters;
+
+use Exception;
+use Illuminate\Http\JsonResponse;
+
+class AuthenticationExceptionFormatter extends ExceptionFormatter
+{
+    public function format(JsonResponse $response, Exception $e, array $reporterResponses)
+    {
+        // build the basic exception
+        parent::format($response, $e, $reporterResponses);
+
+        $httpstatus = 401;
+
+        // add the http status
+        $response->setStatusCode($httpstatus);
+        $data = $response->getData(true);
+
+        $data = array_merge($data, [
+            'status_code' => $httpstatus,
+            'errors' => 'Missing or invalid Access Token!',
+        ]);
+
+        $response->setData($data);
+    }
+}

--- a/app/Ship/Exceptions/Formatters/AuthorizationExceptionFormatter.php
+++ b/app/Ship/Exceptions/Formatters/AuthorizationExceptionFormatter.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Ship\Exceptions\Formatters;
+
+use Exception;
+use Illuminate\Http\JsonResponse;
+
+class AuthorizationExceptionFormatter extends ExceptionFormatter
+{
+    public function format(JsonResponse $response, Exception $e, array $reporterResponses)
+    {
+        // build the basic exception
+        parent::format($response, $e, $reporterResponses);
+
+        $httpstatus = 403;
+
+        // add the http status
+        $response->setStatusCode($httpstatus);
+        $data = $response->getData(true);
+
+        $data = array_merge($data, [
+            'status_code' => $httpstatus,
+            'errors' => 'You have no access to this resource!',
+        ]);
+
+        $response->setData($data);
+    }
+}

--- a/app/Ship/Exceptions/Formatters/ExceptionFormatter.php
+++ b/app/Ship/Exceptions/Formatters/ExceptionFormatter.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Ship\Exceptions\Formatters;
+
+use Apiato\Core\Abstracts\Exceptions\Formatters\BaseFormatter;
+use Exception;
+use Illuminate\Http\JsonResponse;
+
+class ExceptionFormatter extends BaseFormatter
+{
+    public function format(JsonResponse $response, Exception $e, array $reporterResponses)
+    {
+        $response->setStatusCode(500);
+        $data = $response->getData(true);
+
+        $data = array_merge($data, [
+            'code' => $e->getCode(),
+            'message' => $e->getMessage(),
+        ]);
+
+        if (config('app.debug')) {
+            $data = array_merge($data, [
+                'exception' => get_class($e),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+            ]);
+        }
+
+        if (config('apiato.api.debug')) {
+            $data = array_merge($data, [
+                'trace' => (string) $e,
+            ]);
+        }
+
+        $response->setData($data);
+    }
+}

--- a/app/Ship/Exceptions/Formatters/HttpExceptionFormatter.php
+++ b/app/Ship/Exceptions/Formatters/HttpExceptionFormatter.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Ship\Exceptions\Formatters;
+
+use Exception;
+use Illuminate\Http\JsonResponse;
+
+class HttpExceptionFormatter extends ExceptionFormatter
+{
+    public function format(JsonResponse $response, Exception $e, array $reporterResponses)
+    {
+        // build the basic exception
+        parent::format($response, $e, $reporterResponses);
+
+        if (count($headers = $e->getHeaders())) {
+            $response->headers->add($headers);
+        }
+
+        // add the http status
+        $response->setStatusCode($e->getStatusCode());
+        $data = $response->getData(true);
+
+        $data = array_merge($data, [
+            'status_code' => $e->getStatusCode(),
+        ]);
+
+        $response->setData($data);
+    }
+}

--- a/app/Ship/Exceptions/Formatters/MethodNotAllowedExceptionFormatter.php
+++ b/app/Ship/Exceptions/Formatters/MethodNotAllowedExceptionFormatter.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Ship\Exceptions\Formatters;
+
+use Exception;
+use Illuminate\Http\JsonResponse;
+
+class MethodNotAllowedExceptionFormatter extends ExceptionFormatter
+{
+    public function format(JsonResponse $response, Exception $e, array $reporterResponses)
+    {
+        // build the basic exception
+        parent::format($response, $e, $reporterResponses);
+
+        $httpstatus = 405;
+
+        // add the http status
+        $response->setStatusCode($httpstatus);
+        $data = $response->getData(true);
+
+        $data = array_merge($data, [
+            'status_code' => $httpstatus,
+            'errors' => 'Method Not Allowed!',
+        ]);
+
+        $response->setData($data);
+    }
+}

--- a/app/Ship/Exceptions/Formatters/UnprocessableEntityHttpExceptionFormatter.php
+++ b/app/Ship/Exceptions/Formatters/UnprocessableEntityHttpExceptionFormatter.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Ship\Exceptions\Formatters;
+
+use Apiato\Core\Abstracts\Exceptions\Formatters\BaseFormatter;
+use Exception;
+use Illuminate\Http\JsonResponse;
+
+class UnprocessableEntityHttpExceptionFormatter extends BaseFormatter
+{
+    public function format(JsonResponse $response, Exception $e, array $reporterResponses)
+    {
+        $response->setStatusCode(422);
+
+        // Laravel validation errors will return JSON string
+        $decoded = json_decode($e->getMessage(), true);
+        // Message was not valid JSON
+        // This occurs when we throw UnprocessableEntityHttpExceptions
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            // Mimick the structure of Laravel validation errors
+            $decoded = [[$e->getMessage()]];
+        }
+
+        // Laravel errors are formatted as {"field": [/*errors as strings*/]}
+        $data = array_reduce($decoded, function ($carry, $item) use ($e) {
+            return array_merge($carry, array_map(function ($current) use ($e) {
+                return [
+                    'status' => '422',
+                    'code' => $e->getCode(),
+                    'title' => 'Validation error',
+                    'detail' => $current
+                ];
+            }, $item));
+        }, []);
+
+        $response->setData([
+            'errors' => $data
+        ]);
+
+        return $response;
+    }
+}

--- a/app/Ship/Exceptions/Formatters/ValidationExceptionFormatter.php
+++ b/app/Ship/Exceptions/Formatters/ValidationExceptionFormatter.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Ship\Exceptions\Formatters;
+
+use Apiato\Core\Abstracts\Exceptions\Formatters\BaseFormatter;
+use Exception;
+use Illuminate\Http\JsonResponse;
+
+class ValidationExceptionFormatter extends BaseFormatter
+{
+    public function format(JsonResponse $response, Exception $e, array $reporterResponses)
+    {
+        $response->setStatusCode(422);
+
+        $data = $response->getData(true);
+
+        $data = array_merge($data, [
+            'errors' => $e->errors(),
+            'code' => $e->getCode(),
+            'message' => $e->getMessage(),
+            'status_code' => 422,
+        ]);
+
+        if (config('app.debug')) {
+            $data = array_merge($data, [
+                'exception' => get_class($e),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+            ]);
+        }
+
+        if (config('apiato.api.debug')) {
+            $data = array_merge($data, [
+                'trace' => (string) $e,
+            ]);
+        }
+
+        $response->setData($data);
+
+        return $response;
+    }
+}

--- a/docs/_docs/components/exceptionformatters.md
+++ b/docs/_docs/components/exceptionformatters.md
@@ -1,0 +1,59 @@
+---
+title: "Exception-Formatters"
+category: "Optional Components"
+order: 16
+---
+
+* [Definition](#definition)
+- [Own Formatters](#own-formatters)
+  - [Registering Own Formatters](#registering-own-formatters)
+
+
+<a name="definition"></a>
+### Definition
+
+Apiato allows you to format the Exceptions as you like. Therefore, Apiato relies on [Heimdal](https://github.com/esbenp/heimdal), which 
+basically provides the required features.
+
+Apiato already provides basic `ExceptionFormatters` for outputting `Exceptions` in a common format. However, depending on your
+response format (e.g., `JSON API`), you may change the provided formatters.
+
+<a name="own-formatters"></a>
+
+## Own Formatters
+
+Apiato lets you define own formatters or override / enhance the already existing ones. Therefore, all Formatters live in
+`App/Ship/Exceptions/Formatters`. 
+Currently, Apiato provides formatters to format basic Exceptions (or HTTP Exceptions) as well as "common" Exceptions like `AuthenticationException` and so on.
+
+`ExceptionFormatters` behave similar to [`Transformers`]({{ site.baseurl }}{% link _docs/components/transformers.md %}), 
+i.e., they `transform` an `Exception` to a well-defined structure (e.g., array).
+
+Take a look at the `ExceptionFormatter` and `HttpExceptionFormatter` to see the basic idea behind this. The `HttpExceptionFormatter`
+extends the `ExceptionFormatter` by adding an additional `http_status` field to the latter.
+
+Say you want to create your own `AwesomeExceptionFormatter`, simply `extend` (or copy/paste) one of the already 
+provided `Formatters` and adjust the structure to your needs.
+
+<a name="registering-own-formatters"></a>
+
+### Registering Own Formatters
+
+In order to tell Apiato to use your new `AwesomeExceptionFormatter` you need to `register` it. This can be done in the 
+`App/Ship/Configs/optimus.heimdal.php` configuration file.
+
+Take a look at the `optimus.heimdal.formatters` key. This array defines a `key-value` list that declares a Mapping between an
+`Exception` class and the corresponding `Formatter`.
+Say, you want to _register_ the `AwesomeExceptionFormatter` for all `HttpExceptions` add a new line to the **top** of this array, like so:
+```php
+'formatters' => [
+    
+    SymfonyException\HttpException::class => \Your\Custom\Namespace\AwesomeExceptionFormatter::class,
+
+    // the already defined exception formatters from Apiato
+    // ...
+]
+```
+
+When throwing an `Exception` with `throw new XException()` the new `AwesomeExceptionFormatter` is used to format the `Exception` respectively.
+


### PR DESCRIPTION
This PR provides the "main implementation" for the "Better Exceptions" for Apiato.
This code relies on the PR that is already provided in `apiato/core` and adds the `ExceptionFormatters`.

This PR allows to customize (i.e., adapt) the way, `Exceptions` are displayed to clients. Thereby, not only the structure itself, but also the available fields of the message can be easily adjusted to your needs. Furthermore, developers may add custom `Formatters` for their own exceptions!

Minor Changes:
- Adapted some "texts" in the `Tests` in order to comply with the changes
- Updated the `CHANGELOG` file
- Added a new Section to the `Docs` to explain the usage of the `ExceptionFormatters`