### PR TITLE
Change Middleware

### DIFF
--- a/app/Ship/Middlewares/Http/ValidateJsonContent.php
+++ b/app/Ship/Middlewares/Http/ValidateJsonContent.php
@@ -26,27 +26,30 @@ class ValidateJsonContent extends Middleware
      */
     public function handle(Request $request, Closure $next)
     {
-        // get the response after the request is done
-        $response = $next($request);
-
+        $acceptHeader = $request->header('accept');
         $contentType = 'application/json';
+
+        // check if the accept header is set to application/json
+        if (strpos($acceptHeader, $contentType) === false) {
+            // if forcing users to have the accept header is enabled, then throw an exception
+            if (Config::get('apiato.requests.force-accept-header')) {
+                throw new MissingJSONHeaderException();
+            }
+        }
+
+        // the request has to be processed, so get the response after the request is done
+        $response = $next($request);
 
         // set Content Languages header in the response | always return Content-Type application/json in the header
         $response->headers->set('Content-Type', $contentType);
 
-        $acceptHeader = $request->header('accept');
-
         // if request doesn't contain in header accept = application/json. Return a warning in the response
         if (strpos($acceptHeader, $contentType) === false) {
-
-            // if forcing users to have the accept header is enabled, then throw an exception else just send warning
-            if(Config::get('apiato.requests.force-accept-header')){
-                throw new MissingJSONHeaderException();
-            }
 
             $warnCode = '199'; // https://www.iana.org/assignments/http-warn-codes/http-warn-codes.xhtml
             $warnMessage = 'Missing request header [ accept = ' . $contentType . ' ] when calling a JSON API.';
             $response->headers->set('Warning', $warnCode . ' ' . $warnMessage);
+
         }
 
         // return the response


### PR DESCRIPTION
This PR slightly adapts the `ValidateJsonContent` middleware.

Changes:
If the config flag `apiato.requests.force-accept-header` is set to `true` but it is not sent to the API, throw an `Exception` immediately.. In this case, the request does not need to be processed - because it will fail (preconditions are not met)