### PR TITLE
New Route

### DIFF
--- a/app/Containers/Localization/Actions/GetAllLocalizationsAction.php
+++ b/app/Containers/Localization/Actions/GetAllLocalizationsAction.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Containers\Localization\Actions;
+
+use App\Ship\Parents\Actions\Action;
+use App\Ship\Parents\Requests\Request;
+use Apiato\Core\Foundation\Facades\Apiato;
+
+class GetAllLocalizationsAction extends Action
+{
+    public function run(Request $request)
+    {
+        $localizations = Apiato::call('Localization@GetAllLocalizationsTask');
+
+        return $localizations;
+    }
+}

--- a/app/Containers/Localization/Models/Localization.php
+++ b/app/Containers/Localization/Models/Localization.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Containers\Localization\Models;
+
+use Apiato\Core\Traits\HashIdTrait;
+use Apiato\Core\Traits\HasResourceKeyTrait;
+use App\Ship\Parents\Models\Model;
+
+class Localization //extends Model
+{
+    use HashIdTrait;
+    use HasResourceKeyTrait;
+
+    public $code;
+
+    public function __construct($code)
+    {
+        $this->code = $code;
+    }
+
+    /**
+     * A resource key to be used by the the JSON API Serializer responses.
+     */
+    protected $resourceKey = 'localizations';
+}

--- a/app/Containers/Localization/Models/Localization.php
+++ b/app/Containers/Localization/Models/Localization.php
@@ -4,7 +4,8 @@ namespace App\Containers\Localization\Models;
 
 use Apiato\Core\Traits\HashIdTrait;
 use Apiato\Core\Traits\HasResourceKeyTrait;
-use App\Ship\Parents\Models\Model;
+use Illuminate\Support\Facades\Config;
+use Locale;
 
 class Localization //extends Model
 {
@@ -22,4 +23,12 @@ class Localization //extends Model
      * A resource key to be used by the the JSON API Serializer responses.
      */
     protected $resourceKey = 'localizations';
+
+    public function getDefaultName() {
+        return Locale::getDisplayLanguage($this->code, Config::get('app.locale'));
+    }
+
+    public function getLocaleName() {
+        return Locale::getDisplayLanguage($this->code, $this->code);
+    }
 }

--- a/app/Containers/Localization/Tasks/GetAllLocalizationsTask.php
+++ b/app/Containers/Localization/Tasks/GetAllLocalizationsTask.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Containers\Localization\Tasks;
+
+use App\Containers\Localization\Data\Repositories\LocalizationRepository;
+use App\Containers\Localization\Models\Localization;
+use App\Ship\Parents\Tasks\Task;
+use Illuminate\Support\Facades\Config;
+
+class GetAllLocalizationsTask extends Task
+{
+
+    public function run()
+    {
+        $supported_localizations = Config::get('localization-container.supported_languages');
+
+        $localizations = collect();
+
+        foreach ($supported_localizations as $key => $value) {
+            $localizations->push(new Localization($key));
+        }
+
+        return $localizations;
+    }
+}

--- a/app/Containers/Localization/UI/API/Controllers/Controller.php
+++ b/app/Containers/Localization/UI/API/Controllers/Controller.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Containers\Localization\UI\API\Controllers;
+
+use Apiato\Core\Foundation\Facades\Apiato;
+use App\Containers\Localization\UI\API\Requests\GetAllLocalizationsRequest;
+use App\Containers\Localization\UI\API\Transformers\LocalizationTransformer;
+use App\Ship\Parents\Controllers\ApiController;
+
+class Controller extends ApiController
+{
+    /**
+     * Get all supported Localizations of the application.
+     *
+     * @param GetAllLocalizationsRequest $request
+     *
+     * @return array
+     */
+    public function getAllLocalizations(GetAllLocalizationsRequest $request)
+    {
+        $localizations = Apiato::call('Localization@GetAllLocalizationsAction', [$request]);
+
+        return $this->transform($localizations, LocalizationTransformer::class);
+    }
+}

--- a/app/Containers/Localization/UI/API/Requests/GetAllLocalizationsRequest.php
+++ b/app/Containers/Localization/UI/API/Requests/GetAllLocalizationsRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Containers\Localization\UI\API\Requests;
+
+use App\Ship\Parents\Requests\Request;
+
+/**
+ * Class GetAllLocalizationsRequest.
+ */
+class GetAllLocalizationsRequest extends Request
+{
+    /**
+     * Define which Roles and/or Permissions has access to this request.
+     *
+     * @var  array
+     */
+    protected $access = [
+        'permissions' => '',
+        'roles'       => '',
+    ];
+
+    /**
+     * Id's that needs decoding before applying the validation rules.
+     *
+     * @var  array
+     */
+    protected $decode = [
+
+    ];
+
+    /**
+     * Defining the URL parameters (e.g, `/user/{id}`) allows applying
+     * validation rules on them and allows accessing them like request data.
+     *
+     * @var  array
+     */
+    protected $urlParameters = [
+
+    ];
+
+    /**
+     * @return  array
+     */
+    public function rules()
+    {
+        return [
+
+        ];
+    }
+
+    /**
+     * @return  bool
+     */
+    public function authorize()
+    {
+        return $this->check([
+            'hasAccess',
+        ]);
+    }
+}

--- a/app/Containers/Localization/UI/API/Routes/GetAllLocalizations.v1.private.php
+++ b/app/Containers/Localization/UI/API/Routes/GetAllLocalizations.v1.private.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @apiGroup           Localization
+ * @apiName            getAllLocalizations
+ *
+ * @api                {GET} /v1/localizations Get all localizations
+ * @apiDescription     Return all available localizations that are "configured" in the application
+ *
+ * @apiVersion         1.0.0
+ * @apiPermission      none
+ *
+ * @apiParam           {String}  parameters here..
+ *
+ * @apiSuccessExample  {json}  Success-Response:
+ * HTTP/1.1 200 OK
+{
+  // Insert the response of the request here...
+}
+ */
+
+/** @var Route $router */
+$router->get('localizations', [
+    'as' => 'api_localization_get_all_localizations',
+    'uses'  => 'Controller@getAllLocalizations',
+    'middleware' => [
+      'auth:api',
+    ],
+]);

--- a/app/Containers/Localization/UI/API/Transformers/LocalizationTransformer.php
+++ b/app/Containers/Localization/UI/API/Transformers/LocalizationTransformer.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Containers\Localization\UI\API\Transformers;
+
+use App\Containers\Localization\Models\Localization;
+use App\Ship\Parents\Transformers\Transformer;
+use Illuminate\Support\Facades\Config;
+use Locale;
+
+class LocalizationTransformer extends Transformer
+{
+    /**
+     * @var  array
+     */
+    protected $defaultIncludes = [
+
+    ];
+
+    /**
+     * @var  array
+     */
+    protected $availableIncludes = [
+
+    ];
+
+    /**
+     * @param Localization $entity
+     *
+     * @return array
+     */
+    public function transform(Localization $entity)
+    {
+        $response = [
+            'object' => 'Localization',
+            'id' => $entity->code,
+
+            'code' => $entity->code,
+            'default_name' => Locale::getDisplayLanguage($entity->code, Config::get('app.locale')),
+            'locale_name' => Locale::getDisplayLanguage($entity->code, $entity->code),
+        ];
+
+        $response = $this->ifAdmin([
+
+        ], $response);
+
+        return $response;
+    }
+}

--- a/app/Containers/Localization/UI/API/Transformers/LocalizationTransformer.php
+++ b/app/Containers/Localization/UI/API/Transformers/LocalizationTransformer.php
@@ -4,8 +4,6 @@ namespace App\Containers\Localization\UI\API\Transformers;
 
 use App\Containers\Localization\Models\Localization;
 use App\Ship\Parents\Transformers\Transformer;
-use Illuminate\Support\Facades\Config;
-use Locale;
 
 class LocalizationTransformer extends Transformer
 {
@@ -35,8 +33,8 @@ class LocalizationTransformer extends Transformer
             'id' => $entity->code,
 
             'code' => $entity->code,
-            'default_name' => Locale::getDisplayLanguage($entity->code, Config::get('app.locale')),
-            'locale_name' => Locale::getDisplayLanguage($entity->code, $entity->code),
+            'default_name' => $entity->getDefaultName(),
+            'locale_name' => $entity->getLocaleName(),
         ];
 
         $response = $this->ifAdmin([


### PR DESCRIPTION
This PR provides a new `/localizations` route for the application.

This route, in turn, provides information about the `supported_localizations` of the application (found in `Config::get(localization-container.supported_localizations)`).

The Transformer outputs the
- `code` of the localization (e.g., `de`)
- `default_name` of the localization in the `app.locale` (default) language (e.g., `German` if you run your application in `en`)
- `locale_name' of the localization in the localized language (e.g., `Deutsch` for `de`).

So basically, you get the name in the specific language AND in the default language of the application

Hope this helps someone.. 