### PR TITLE
[Improvement] Localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 - Changed the `Content-Language` header field (for requesting resources in a specific language) to `Accept-Language` instead (cf. [Specs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language)).
+- The structure of the `supported_languages` in `App/Containers/Localization/Configs` was changed in order to support `regions`.
 
 ### Fixed
 - ... 

--- a/app/Containers/Localization/Configs/localization-container.php
+++ b/app/Containers/Localization/Configs/localization-container.php
@@ -14,10 +14,13 @@ return [
     */
 
     'supported_languages' => [
-        'ar' => 'Arabic',
-        'en' => 'English',
-        'es' => 'Spanish',
-        'fr' => 'French',
+        'ar',
+        'en' => [
+            'en-GB',
+            'en-US',
+        ],
+        'es',
+        'fr',
     ],
 
 ];

--- a/app/Containers/Localization/Middlewares/LocalizationMiddleware.php
+++ b/app/Containers/Localization/Middlewares/LocalizationMiddleware.php
@@ -4,10 +4,12 @@ namespace App\Containers\Localization\Middlewares;
 
 use App\Containers\Localization\Exceptions\UnsupportedLanguageException;
 use App\Ship\Parents\Middlewares\Middleware;
+use ArrayIterator;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Str;
 
 /**
  * Class LocalizationMiddleware
@@ -61,9 +63,12 @@ class LocalizationMiddleware extends Middleware
         // split it up by ","
         $languages = explode(',', $request_languages);
 
+        // we need an ArrayIterator because we will be extending the FOREACH below dynamically!
+        $language_iterator = new ArrayIterator($languages);
+
         $supported_languages = $this->getSupportedLanguages();
 
-        foreach ($languages as $language)
+        foreach ($language_iterator as $language)
         {
             // split it up by ";"
             $locale = explode(';', $language);
@@ -71,9 +76,17 @@ class LocalizationMiddleware extends Middleware
             $current_locale = $locale[0];
 
             // now check, if this locale is "supported"
-            if ( array_key_exists($current_locale, $supported_languages))
+            if (array_search($current_locale, $supported_languages) !== false)
             {
                 return $current_locale;
+            }
+
+            // now check, if the language to be checked is in the form of de-DE
+            if (Str::contains($current_locale, '-'))
+            {
+                // extract the "main" part ("de") and append it to the end of the languages to be checked
+                $base = explode('-', $current_locale);
+                $language_iterator[] = $base[0];
             }
         }
 
@@ -92,7 +105,13 @@ class LocalizationMiddleware extends Middleware
          * read the accept-language from the request
          * if the header is missing, use the default local language
          */
-        return $request->header('Accept-Language') ? : Config::get('app.locale');
+        $language = Config::get('app.locale');
+
+        if ($request->hasHeader('Accept-Language')) {
+            $language = $request->header('Accept-Language');
+        }
+
+        return $language;
     }
 
     /**
@@ -100,7 +119,27 @@ class LocalizationMiddleware extends Middleware
      */
     private function getSupportedLanguages()
     {
-        return Config::get('localization-container.supported_languages');
+        $supported_locales = [];
+
+        $locales = Config::get('localization-container.supported_languages');
+
+        foreach ($locales as $key => $value) {
+            // it is a "simple" language code (e.g., "en")!
+            if (! is_array($value))
+            {
+                $supported_locales[] = $value;
+            }
+
+            // it is a combined language-code (e.g., "en-US")
+            if (is_array($value)) {
+                foreach ($value as $k => $v) {
+                    $supported_locales[] = $v;
+                }
+                $supported_locales[] = $key;
+            }
+        }
+
+        return $supported_locales;
     }
 
 }

--- a/app/Containers/Localization/Models/Localization.php
+++ b/app/Containers/Localization/Models/Localization.php
@@ -12,11 +12,16 @@ class Localization //extends Model
     use HashIdTrait;
     use HasResourceKeyTrait;
 
-    public $code;
+    private $language = null;
+    private $regions = [];
 
-    public function __construct($code)
+    public function __construct($language, array $regions = [])
     {
-        $this->code = $code;
+        $this->language = $language;
+
+        foreach ($regions as $region) {
+            $this->regions[] = new Region($region);
+        }
     }
 
     /**
@@ -25,10 +30,18 @@ class Localization //extends Model
     protected $resourceKey = 'localizations';
 
     public function getDefaultName() {
-        return Locale::getDisplayLanguage($this->code, Config::get('app.locale'));
+        return Locale::getDisplayLanguage($this->language, Config::get('app.locale'));
     }
 
     public function getLocaleName() {
-        return Locale::getDisplayLanguage($this->code, $this->code);
+        return Locale::getDisplayLanguage($this->language, $this->language);
+    }
+
+    public function getLanguage() {
+        return $this->language;
+    }
+
+    public function getRegions() {
+        return $this->regions;
     }
 }

--- a/app/Containers/Localization/Models/Region.php
+++ b/app/Containers/Localization/Models/Region.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Containers\Localization\Models;
+
+use Illuminate\Support\Facades\Config;
+use Locale;
+
+class Region //extends Model
+{
+    private $region = null;
+
+    public function __construct($region)
+    {
+        $this->region = $region;
+    }
+
+    /**
+     * A resource key to be used by the the JSON API Serializer responses.
+     */
+    protected $resourceKey = 'regions';
+
+    public function getDefaultName() {
+        return Locale::getDisplayRegion($this->region, Config::get('app.locale'));
+    }
+
+    public function getLocaleName() {
+        return Locale::getDisplayRegion($this->region, $this->region);
+    }
+
+    public function getRegion() {
+        return $this->region;
+    }
+}

--- a/app/Containers/Localization/Resources/Languages/en-GB/messages.php
+++ b/app/Containers/Localization/Resources/Languages/en-GB/messages.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+    'welcome' => 'Welcome to Apiato (GB)',
+
+];

--- a/app/Containers/Localization/Tasks/GetAllLocalizationsTask.php
+++ b/app/Containers/Localization/Tasks/GetAllLocalizationsTask.php
@@ -24,8 +24,17 @@ class GetAllLocalizationsTask extends Task
 
         $localizations = new Collection();
 
-        foreach ($supported_localizations as $key => $value) {
-            $localizations->push(new Localization($key));
+        foreach ($supported_localizations as $key => $value)
+        {
+            // it is a simple key
+            if (! is_array($value)) {
+                $localizations->push(new Localization($value));
+            }
+
+            // it is a composite key
+            if (is_array($value)) {
+                $localizations->push(new Localization($key, $value));
+            }
         }
 
         return $localizations;

--- a/app/Containers/Localization/UI/API/Transformers/LocalizationTransformer.php
+++ b/app/Containers/Localization/UI/API/Transformers/LocalizationTransformer.php
@@ -35,12 +35,31 @@ class LocalizationTransformer extends Transformer
     {
         $response = [
             'object' => 'Localization',
-            'id' => $entity->code,
+            'id' => $entity->getLanguage(),
 
-            'code' => $entity->code,
-            'default_name' => $entity->getDefaultName(),
-            'locale_name' => $entity->getLocaleName(),
+            'language' => [
+                'code' => $entity->getLanguage(),
+                'default_name' => $entity->getDefaultName(),
+                'locale_name' => $entity->getLocaleName(),
+            ],
         ];
+
+        // now we manually build the regions
+        $regions = [];
+        $entity_regions = $entity->getRegions();
+
+        foreach ($entity_regions as $region) {
+            $regions[] = [
+                'code' => $region->getRegion(),
+                'default_name' => $region->getDefaultName(),
+                'locale_name' => $region->getLocaleName(),
+            ];
+        }
+
+        // now add the regions
+        $response = array_merge($response, [
+            'regions' => $regions,
+        ]);
 
         $response = $this->ifAdmin([
 

--- a/app/Containers/Welcome/Actions/FindMessageForApiRootVisitorAction.php
+++ b/app/Containers/Welcome/Actions/FindMessageForApiRootVisitorAction.php
@@ -18,6 +18,6 @@ class FindMessageForApiRootVisitorAction extends Action
      */
     public function run()
     {
-        return ['Welcome to ' . Config::get('app.name') . '.'];
+        return [trans('localization::messages.welcome')];
     }
 }

--- a/app/Containers/Welcome/Actions/FindMessageForApiV1VisitorAction.php
+++ b/app/Containers/Welcome/Actions/FindMessageForApiV1VisitorAction.php
@@ -18,6 +18,6 @@ class FindMessageForApiV1VisitorAction extends Action
      */
     public function run()
     {
-        return ['Welcome to ' . Config::get('app.name') . ' (API V1).'];
+        return [trans('localization::messages.welcome') . ' (API V1)'];
     }
 }

--- a/docs/_docs/features/localization.md
+++ b/docs/_docs/features/localization.md
@@ -4,68 +4,115 @@ category: "Features"
 order: 15
 ---
 
-- [Select response language](#select-response-language)
+- [Select Request Language](#select-request-language)
 - [Support new language](#support-new-language)
-- [Namespaces](#namespaces)
+- [Translating Strings](#namespaces)
 - [Disable Localization](#disable-localization)
+- [Get Available Localizations](#get-available-localizations)
 - [Tests](#tests)
 
 <br>
 <br>
 The Localization is provided by the Localization Container.
 <br>
-<a name="select-response-language"></a>
 
-## Select response language
+<a name="select-request-language"></a>
 
-You can choose the language of the response by adding the header `Content-Language` to the request.
+## Select Request Language
 
-By default the `Content-Language` is set to `en`.
+You can select the language of the response by adding the header `Accept-Language` to the request. By default the 
+`Accept-Language` is set to the language defined in `config/app.php` `locale`. 
 
-You can change the default language from the `config/app.php` `locale`.
+Please note that `Accept-Language` only determines, that the client _would like_ to get the information in this specific
+language. It is not given, that the API responds in this language!
 
-When the `Content-Language` header is missed the default will always be used.
+When the `Accept-Language` header is missing, the default locale will be applied.
 
-And the response will also contain the default language in the `Content-Language` header.
+> **Heads up!**
+> Please be sure that your client does not send an `Accept-Language` header automatically. Some REST clients 
+(e.g., `POSTMAN`) automatically add header-fields based on the operating-systems settings. So your `Accept-Language` header
+may be set automatically without knowing!
+
+The API will answer with the applied language in the `Content-Language` header of the response.
+
+If the requested language cannot be resolved (e.g., it is not defined) the API throws an `UnsupportedLanguageException` to tell 
+the client about this.
+
+The overall workflow of the Middleware is as follows:
+1) Extract the `Accept-Language` field from the request header. If none is set, use the default locale from the config file
+2) Build a list of all supported localizations based on the configuration of the respective container. If a language 
+(top level) contains regions (sub-level), order them like this: `['en-GB', 'en-US', 'en']` (the regions before languages, 
+as regions are more specific)
+3) Check, if the value from 1) is within the list from 2). If the value is within this list, set it as application language, 
+if not throw an `Exception`.
 
 <a name="support-new-language"></a>
 
 ## Support new language
 
-1. All supported languages must be added to the `supported_languages` in `app/Containers/Localization/Configs/localization.php` to prevent users from requesting unsupported languages, as follow:
+1. All supported languages must be added to the `supported_languages` in `app/Containers/Localization/Configs/localization.php` 
+to prevent users from requesting unsupported languages, as follow:
 
 ```php
 <?php
 
     'supported_languages' => [
-        'en' => 'English',
-        'ar' => 'Arabic',
-        'fr' => 'French',
-        'ru' => 'Russian',
+        'ar',
+        'en' => [
+            'en-GB',
+            'en-US',
+        ],
+        'es',
+        'fr',
     ],
 ```
 
-2. Create your languages files:
+2. Create new languages files:
 
-Languages file can be placed in any container, not only the Localization Container. Refer to the [Localization]({{ site.baseurl }}{% link _docs/features/localization.md %}) page for more info.
+Languages file can be placed in any container, not only the Localization Container. Refer to the [Localization]({{ site.baseurl }}{% link _docs/features/localization.md %}) 
+page for more info.
 
 Example languages files are included in the Localization Container at `app/Containers/Localization/Resources/Languages`.
 
 <a name="namespaces"></a>
 
-## Namespaces
+## Translating Strings
 
 By default all the Container translation files are namespaced to the Container name.
 
 **Example:**
 
-If a Container named `Store` has `en` translation file called `notifications` that contains translation for  `welcome` as "Welcome to our store :)". You can access this translation as follow `trans('store::notifications.welcome')`. If you remove the namespace (which is the lowercase of the container name) and try to access it like this `trans('notifications.welcome')` it will not find your translation and will print `notifications.welcome` only.
+If a Container named `Store` has `en` translation file called `notifications` that contains translation for `welcome` 
+like "Welcome to our store :)". You can access this translation as follow `trans('store::notifications.welcome')`. If 
+you remove the namespace (which is the lowercase of the container name) and try to access it like this 
+`trans('notifications.welcome')` it will not find your translation and will print `notifications.welcome` only.
+
+> **Heads up!**
+> If you try to load a string for a language that is **not available** (e.g., there is no folder for this language), Apiato 
+will stick to the default one that is defined in `app.locale` config file. This is also true, if the requested locale 
+is present in the `supported_languages` array from the configuration file.
 
 <a name="disable-localization"></a>
 
 ## Disable Localization
 
-You will need to remove the Localization Middleware, by simply going to `app/Containers/Localization/Providers/MainServiceProvider.php` and removing the `MiddlewareServiceProvider` from the `$serviceProviders` property.
+You will need to remove the Localization Middleware, by simply going to `app/Containers/Localization/Providers/MainServiceProvider.php` 
+and removing the `MiddlewareServiceProvider` from the `$serviceProviders` property.
+
+<a name="get-available-localizations"></a>
+
+## Get Available Localizations
+
+Apiato provides a convenient way to get all defined localizations. These localizations can be retrieved via `GET /localizations` 
+by default. Note that this route only outputs the "top level" locales, like `en` from the example above. However, if 
+specific regions (e.g., `en-US`) are defined, these will show up in the result as well.
+
+The `Transformer` for the localizations not only provide the `language` (e.g., `de`), but also outputs the name of the 
+language in this specific language (e.g., `locale_name => Deutsch`). Furthermore, the language name is outputted in the 
+applications default name (e.g., configured in `app.locale`). This would result in `default_name => German`.
+ 
+The same applies to the regions that are defined (e.g., `de-DE`). Consequently, this results in `locale_name => Deutschland` 
+and `default_name = Germany`.
 
 <a name="tests"></a>
 


### PR DESCRIPTION
This PR improves the currently available `LocalizationMiddleware` as well as the associated `GET /localizations` route.

Major:
- The structure of the `supported_languages` in the config file now supports "regions" (e.g., `en-GB`) as well. **Unfortunately, this is not backwards-compatible!**
- The middleware logic is highly improved in order to support regions as well.
- Added a new `Region` model in order to reflect these changes
- The `GET /localizations` route now outputs the (possibly) defined "regions" as well.
- Updated the docs and changelog accordingly

Minor:
- Let the `Welcome` container use the `trans(...)` method in order to show the translation in action