### PR TITLE
Make LOGOUT use DELETE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Changed the `Content-Language` header field (for requesting resources in a specific language) to `Accept-Language` instead (cf. [Specs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language)).
 - Rename `GiveAllPermissionsToRole` to `GiveAllPermissionsToRoleCommand`.
 - The structure of the `supported_languages` in `App/Containers/Localization/Configs` was changed in order to support `regions`.
+- The route `/logout` now uses `DELETE` instead of `POST` (to be more RESTful)
 
 ### Fixed
 - ... 

--- a/app/Containers/Authentication/UI/API/Routes/Logout.v1.public.php
+++ b/app/Containers/Authentication/UI/API/Routes/Logout.v1.public.php
@@ -2,7 +2,7 @@
 /**
  * @apiGroup           OAuth2
  * @apiName            Logout
- * @api                {post} /v1/logout
+ * @api                {DELETE} /v1/logout
  * @apiDescription     User Logout. (Revoking Access Token)
  *
  * @apiVersion         1.0.0
@@ -14,7 +14,7 @@
   "message": "Token revoked successfully."
 }
  */
-$router->post('logout', [
+$router->delete('logout', [
     'as' => 'api_authentication_logout',
     'uses'  => 'Controller@logout',
     'middleware' => [


### PR DESCRIPTION
This PR makes the `/logout` route use `DELETE` instead of `POST` in order to be more RESTful..