### PR TITLE
Fix Transformer Include Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- ...
+- Added a new config flag (`apiato.requests.force-valid-includes` (default `true`)) to notify users about potential "invalid" `?include` query parameters
 
 ### Changed
 - Changed the `Content-Language` header field (for requesting resources in a specific language) to `Accept-Language` instead (cf. [Specs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language)).
@@ -11,7 +11,7 @@
 - The structure of the `supported_languages` in `App/Containers/Localization/Configs` was changed in order to support `regions`.
 
 ### Fixed
-- ... 
+- Fixed "bug", where an Exception is thrown if the user requested an invalid `?include` parameter. Now a "real" Apiato Exception is thrown.
 
 ### Removed
 - ...

--- a/app/Ship/Configs/apiato.php
+++ b/app/Ship/Configs/apiato.php
@@ -125,7 +125,7 @@ return [
         | Force Request Header to Contain header
         |--------------------------------------------------------------------------
         |
-        | By default users can send request without defining the accept header and
+        | By default, users can send request without defining the accept header and
         | setting it to [ accept = application/json ].
         | To force the users to define that header, set this to true.
         | When set to true, a PHP exception will be thrown preventing users from access
@@ -133,6 +133,22 @@ return [
         |
         */
         'force-accept-header' => false,
+
+        /*
+        |--------------------------------------------------------------------------
+        | Force Valid Request Include Parameters
+        |--------------------------------------------------------------------------
+        |
+        | By default, users can request to include additional resources into the
+        | response by using the ?include=... query parameter. The requested top-level
+        | resource also responds with all available includes. However, the user may
+        | still request an invalid (i.e., not available) include parameter. This flag
+        | determines, how to proceed in such a case:
+        | When set to true, a PHP Exception will be thrown (default)
+        | When set to false, this invalid include will be skipped
+        |
+        */
+        'force-valid-includes' => true,
 
         /*
         |--------------------------------------------------------------------------

--- a/app/Ship/Exceptions/UnsupportedFractalIncludeException.php
+++ b/app/Ship/Exceptions/UnsupportedFractalIncludeException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Ship\Exceptions;
+
+use App\Ship\Parents\Exceptions\Exception;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+
+/**
+ * Class UnsupportedFractalIncludeException.
+ *
+ * @author  Johannes Schobel <johannes.schobel@googlemail.com>
+ */
+class UnsupportedFractalIncludeException extends Exception
+{
+
+    public $httpStatusCode = SymfonyResponse::HTTP_BAD_REQUEST;
+
+    public $message = 'Requested a invalid Include Parameter.';
+
+}

--- a/app/Ship/Parents/Transformers/Transformer.php
+++ b/app/Ship/Parents/Transformers/Transformer.php
@@ -3,6 +3,12 @@
 namespace App\Ship\Parents\Transformers;
 
 use Apiato\Core\Abstracts\Transformers\Transformer as AbstractTransformer;
+use App\Ship\Exceptions\InternalErrorException;
+use App\Ship\Exceptions\UnsupportedFractalIncludeException;
+use ErrorException;
+use Exception;
+use Illuminate\Support\Facades\Config;
+use League\Fractal\Scope;
 
 /**
  * Class Transformer.
@@ -11,5 +17,28 @@ use Apiato\Core\Abstracts\Transformers\Transformer as AbstractTransformer;
  */
 abstract class Transformer extends AbstractTransformer
 {
+    /**
+     * @param Scope  $scope
+     * @param string $includeName
+     * @param mixed  $data
+     *
+     * @return \League\Fractal\Resource\ResourceInterface
+     * @throws InternalErrorException
+     * @throws UnsupportedFractalIncludeException
+     */
+    protected function callIncludeMethod(Scope $scope, $includeName, $data)
+    {
+        try {
+            return parent::callIncludeMethod($scope, $includeName, $data);
+        }
+        catch (ErrorException $exception) {
+            if (Config::get('apiato.requests.force-valid-includes', true)) {
+                throw new UnsupportedFractalIncludeException();
+            }
+        }
+        catch (Exception $exception) {
+            throw new InternalErrorException();
+        }
+    }
 
 }


### PR DESCRIPTION
This PR fixes the bug mentioned in https://github.com/apiato/apiato/issues/203

## Problem
Imagine the `UserTransformer` that provides an `include` parameter for `roles`. If the client now requests `?include=role` (note the missing `s`!), this would result in an Exception, that respective method (`includeUser()`) could not be found.

## Fix
Mainly this fix just overrides the already existing method from `Fractal` and adds an additional Exception block to this. I initially submitted a PR to `league/fractal` in order to fix this issue but it was never merged..

The behavior to `throw an exception` or just `exclude this invalid include parameter` can be customized with a newly added config flag ( `apiato.requests.force-valid-includes`).

More details can be found in the mentioned issue above! 