### PR TITLE
Add MyselfTransformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - The route `/logout` now uses `DELETE` instead of `POST` (to be more RESTful)
 - Move `Localization` and `Region` from Model to ValueObjects folder in the localization container.
 - Move `Output` and `RequestLogger` from Model to ValueObjects folder in the debugger container.
+- The route `/user/profile` (the profile of the current user) now uses a dedicated `MyselfTransformer` in order to allow adding "private" information more easily (instead of using if-blocks in the `UserTransformer`) 
 
 ### Fixed
 - Fixed "bug", where an Exception is thrown if the user requested an invalid `?include` parameter. Now a "real" Apiato Exception is thrown.

--- a/app/Containers/User/UI/API/Controllers/Controller.php
+++ b/app/Containers/User/UI/API/Controllers/Controller.php
@@ -10,6 +10,7 @@ use App\Containers\User\UI\API\Requests\FindUserByIdRequest;
 use App\Containers\User\UI\API\Requests\GetAllUsersRequest;
 use App\Containers\User\UI\API\Requests\RegisterUserRequest;
 use App\Containers\User\UI\API\Requests\UpdateUserRequest;
+use App\Containers\User\UI\API\Transformers\MyselfTransformer;
 use App\Containers\User\UI\API\Transformers\UserTransformer;
 use App\Ship\Parents\Controllers\ApiController;
 
@@ -126,7 +127,7 @@ class Controller extends ApiController
     {
         $user = Apiato::call('User@GetAuthenticatedUserAction', [$request]);
 
-        return $this->transform($user, UserTransformer::class, ['roles']);
+        return $this->transform($user, MyselfTransformer::class);
     }
 
 }

--- a/app/Containers/User/UI/API/Transformers/MyselfTransformer.php
+++ b/app/Containers/User/UI/API/Transformers/MyselfTransformer.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Containers\User\UI\API\Transformers;
+
+use App\Containers\Authorization\UI\API\Transformers\RoleTransformer;
+use App\Containers\User\Models\User;
+use App\Ship\Parents\Transformers\Transformer;
+
+/**
+ * Class MyselfTransformer.
+ *
+ * @author Johannes Schobel <johannes.schobel@googlemail.com>
+ */
+class MyselfTransformer extends Transformer
+{
+
+    /**
+     * @var  array
+     */
+    protected $availableIncludes = [
+        'roles',
+    ];
+
+    /**
+     * @var  array
+     */
+    protected $defaultIncludes = [
+
+    ];
+
+    /**
+     * @param \App\Containers\User\Models\User $user
+     *
+     * @return array
+     */
+    public function transform(User $user)
+    {
+        $response = [
+            'object'               => 'User',
+            'id'                   => $user->getHashedKey(),
+            'name'                 => $user->name,
+            'email'                => $user->email,
+            'confirmed'            => $user->confirmed,
+            'nickname'             => $user->nickname,
+            'gender'               => $user->gender,
+            'birth'                => $user->birth,
+
+            'social_auth_provider' => $user->social_provider,
+            'social_id'            => $user->social_id,
+            'social_avatar'        => [
+                'avatar'   => $user->social_avatar,
+                'original' => $user->social_avatar_original,
+            ],
+
+            'created_at'           => $user->created_at,
+            'updated_at'           => $user->updated_at,
+            'readable_created_at'  => $user->created_at->diffForHumans(),
+            'readable_updated_at'  => $user->updated_at->diffForHumans(),
+        ];
+
+        $response = $this->ifAdmin([
+            'real_id'    => $user->id,
+            'deleted_at' => $user->deleted_at,
+        ], $response);
+
+        return $response;
+    }
+
+    public function includeRoles(User $user)
+    {
+        return $this->collection($user->roles, new RoleTransformer());
+    }
+
+}


### PR DESCRIPTION
This PR adds a new `MyselfTransformer` for the "my own Profile" (`/user/profile`) route. This makes adding "private information" (e.g., configuration settings, ...) to this route much easier, as there is a dedicated `Transformer` for this route.

Otherwise, this would require `if/else` blocks in the `UserTransformer`, which could be hard to read / maintain.. 