### PR TITLE
add LEVEL to ROLE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Added a new config flag (`apiato.requests.force-valid-includes` (default `true`)) to notify users about potential "invalid" `?include` query parameters
 - Added ValueObjects class type to be extended by classes that do not requires to be stored in the DB or have ID.
+- Added a `level` to the roles in order to indicate some kind of hierarchy (e.g., `admin` is "better" than `manager`).
 
 ### Changed
 - Changed the `Content-Language` header field (for requesting resources in a specific language) to `Accept-Language` instead (cf. [Specs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language)).

--- a/app/Containers/Authorization/Actions/CreateRoleAction.php
+++ b/app/Containers/Authorization/Actions/CreateRoleAction.php
@@ -21,7 +21,14 @@ class CreateRoleAction extends Action
      */
     public function run(Request $request)
     {
+
+        $level = 0;
+        if ($request->has('level')) {
+            $level = $request->level;
+        }
+
         return Apiato::call('Authorization@CreateRoleTask',
-            [$request->name, $request->description, $request->display_name]);
+            [$request->name, $request->description, $request->display_name, $level]
+        );
     }
 }

--- a/app/Containers/Authorization/Data/Migrations/2017_10_27_091547_update_roles_table.php
+++ b/app/Containers/Authorization/Data/Migrations/2017_10_27_091547_update_roles_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Config;
+
+class UpdateRolesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table(Config::get('permission.table_names.roles'), function (Blueprint $table) {
+
+            $table->unsignedInteger('level')->default(0);
+
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table(Config::get('permission.table_names.roles'), function (Blueprint $table) {
+
+            $table->dropColumn('level');
+
+        });
+    }
+}

--- a/app/Containers/Authorization/Data/Seeders/AuthorizationRolesSeeder_2.php
+++ b/app/Containers/Authorization/Data/Seeders/AuthorizationRolesSeeder_2.php
@@ -21,7 +21,7 @@ class AuthorizationRolesSeeder_2 extends Seeder
     public function run()
     {
         // Default Roles ----------------------------------------------------------------
-        Apiato::call('Authorization@CreateRoleTask', ['admin', 'Administrator']);
+        Apiato::call('Authorization@CreateRoleTask', ['admin', 'Administrator', 'Administrator Role', 999]);
 
         // ...
 

--- a/app/Containers/Authorization/Models/Role.php
+++ b/app/Containers/Authorization/Models/Role.php
@@ -30,5 +30,6 @@ class Role extends SpatieRole
         'guard_name',
         'display_name',
         'description',
+        'level',
     ];
 }

--- a/app/Containers/Authorization/Tasks/CreateRoleTask.php
+++ b/app/Containers/Authorization/Tasks/CreateRoleTask.php
@@ -15,13 +15,14 @@ class CreateRoleTask extends Task
 {
 
     /**
-     * @param $name
-     * @param $description
-     * @param $displayName
+     * @param     $name
+     * @param     $description
+     * @param     $displayName
+     * @param int $level
      *
-     * @return  mixed
+     * @return mixed
      */
-    public function run($name, $description = null, $displayName = null)
+    public function run($name, $description = null, $displayName = null, $level = 0)
     {
         app()['cache']->forget('spatie.permission.cache');
 
@@ -30,6 +31,7 @@ class CreateRoleTask extends Task
             'description'  => $description,
             'display_name' => $displayName,
             'guard_name'   => 'web',
+            'level'        => $level,
         ]);
     }
 


### PR DESCRIPTION
This PR adds an additional `level` field to `Role` model.

This will allow us to define some kind of "hierarchy" for the `Role` mdoels (e.g., an `admin` is "better" than a `manager`).
Furthermore, this would allow us to use this `level` information on the requests in order to check, if a client has _at least_ the `level x` (e.g,. he must have at least level 100 to access this route).