### PR TITLE
[Feature] forgot and reset password endpoints

### DIFF
--- a/app/Containers/User/Actions/ForgotPasswordAction.php
+++ b/app/Containers/User/Actions/ForgotPasswordAction.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Containers\User\Actions;
+
+use App\Containers\User\Mails\UserForgotPasswordMail;
+use App\Ship\Parents\Actions\Action;
+use Apiato\Core\Foundation\Facades\Apiato;
+use App\Ship\Parents\Requests\Request;
+use Illuminate\Support\Facades\Mail;
+
+class ForgotPasswordAction extends Action
+{
+    public function run(Request $request)
+    {
+        $user = Apiato::call('User@FindUserByEmailTask', [$request->email]);
+        //generate token
+        $token = Apiato::call('User@CreatePasswordResetTask', [$user]);
+
+        //send email
+        if (in_array($reseturl = $request->reseturl, config('user-container.allowed-reset-password-urls'))) Mail::send(new UserForgotPasswordMail($user, $token, $reseturl));
+
+    }
+}

--- a/app/Containers/User/Actions/ResetPasswordAction.php
+++ b/app/Containers/User/Actions/ResetPasswordAction.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Containers\User\Actions;
+
+use App\Ship\Parents\Actions\Action;
+use Apiato\Core\Foundation\Facades\Apiato;
+use App\Ship\Parents\Requests\Request;
+
+class ResetPasswordAction extends Action
+{
+    public function run(Request $request)
+    {
+        $data = [
+            'email' => $request->email,
+            'token' => $request->token,
+            'password' => $request->password,
+            'password_confirmation' => $request->password,
+        ];
+
+        Apiato::call('User@ResetPasswordTask', [$data]);
+
+    }
+}

--- a/app/Containers/User/Configs/user-container.php
+++ b/app/Containers/User/Configs/user-container.php
@@ -11,4 +11,10 @@ return [
     |
     */
 
+    'allowed-reset-password-urls' => [
+
+        // insert your allowed reset password urls to inject into the email here
+        // 'your.domain/resetpassword',
+    ],
+
 ];

--- a/app/Containers/User/Mails/Templates/user-forgotPassword.blade.php
+++ b/app/Containers/User/Mails/Templates/user-forgotPassword.blade.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en-US">
+<head>
+    <meta charset="utf-8">
+</head>
+<body>
+<h3>Reset password</h3>
+<div>
+    Please follow that link to reset your password: <a href="{{$reseturl}}?email={{$email}}&token={{$token}}">{{$reseturl}}?email={{$email}}&token={{$token}}</a>
+</div>
+</body>
+</html>

--- a/app/Containers/User/Mails/UserForgotPasswordMail.php
+++ b/app/Containers/User/Mails/UserForgotPasswordMail.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Containers\User\Mails;
+
+use App\Containers\User\Models\User;
+use App\Ship\Parents\Mails\Mail;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+/**
+ * Class UserForgotPasswordMail
+ */
+class UserForgotPasswordMail extends Mail implements ShouldQueue
+{
+    use Queueable;
+
+    protected $recipient;
+    protected $token;
+    protected $reseturl;
+
+    /**
+     * UserForgotPasswordMail constructor.
+     *
+     * @param User $recipient
+     * @param $token
+     * @param $reseturl
+     */
+    public function __construct(User $recipient, $token, $reseturl)
+    {
+        $this->recipient = $recipient;
+        $this->token = $token;
+        $this->reseturl = $reseturl;
+    }
+
+    public function build()
+    {
+        return $this->view('user::user-forgotPassword')
+            ->to($this->recipient->email, $this->recipient->name)
+            ->with([
+                'token' => $this->token,
+                'reseturl' => $this->reseturl,
+                'email' => $this->recipient->email,
+            ]);
+    }
+}

--- a/app/Containers/User/Tasks/CreatePasswordResetTask.php
+++ b/app/Containers/User/Tasks/CreatePasswordResetTask.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Containers\User\Tasks;
+
+use App\Containers\User\Models\User;
+use App\Ship\Exceptions\CreateResourceFailedException;
+use App\Ship\Parents\Exceptions\Exception;
+use App\Ship\Parents\Tasks\Task;
+
+class CreatePasswordResetTask extends Task
+{
+
+    public function __construct()
+    {
+        // ..
+    }
+
+    public function run(User $user)
+    {
+        try {
+            return app('auth.password.broker')->createToken($user);
+        } catch (Exception $e) {
+            throw new CreateResourceFailedException;
+        }
+    }
+}

--- a/app/Containers/User/Tasks/FindUserByEmailTask.php
+++ b/app/Containers/User/Tasks/FindUserByEmailTask.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Containers\User\Tasks;
+
+use App\Containers\User\Data\Repositories\UserRepository;
+use App\Ship\Exceptions\NotFoundException;
+use App\Ship\Parents\Tasks\Task;
+use Exception;
+
+class FindUserByEmailTask extends Task
+{
+    protected $repository;
+
+    public function __construct(UserRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function run($email)
+    {
+        // find the user by its email
+        try {
+            $user = $this->repository->findByField('email', $email)->first();
+        } catch (Exception $e) {
+            throw new NotFoundException();
+        }
+
+        return $user;
+    }
+}

--- a/app/Containers/User/Tasks/ResetPasswordTask.php
+++ b/app/Containers/User/Tasks/ResetPasswordTask.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Containers\User\Tasks;
+
+use App\Ship\Parents\Exceptions\Exception;
+use App\Ship\Parents\Tasks\Task;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Str;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+
+class ResetPasswordTask extends Task
+{
+
+    public function __construct()
+    {
+        // ..
+    }
+
+    public function run($data)
+    {
+        try {
+            Password::broker()->reset(
+                $data,
+                function ($user, $password) {
+                    $user->forceFill([
+                        'password' => Hash::make($password),
+                        'remember_token' => Str::random(60),
+                    ])->save();
+                }
+            );
+        } catch (Exception $e) {
+            throw new ResourceNotFoundException();
+        }
+    }
+}

--- a/app/Containers/User/UI/API/Controllers/Controller.php
+++ b/app/Containers/User/UI/API/Controllers/Controller.php
@@ -5,10 +5,12 @@ namespace App\Containers\User\UI\API\Controllers;
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\User\UI\API\Requests\CreateAdminRequest;
 use App\Containers\User\UI\API\Requests\DeleteUserRequest;
+use App\Containers\User\UI\API\Requests\ForgotPasswordRequest;
 use App\Containers\User\UI\API\Requests\GetAuthenticatedUserRequest;
 use App\Containers\User\UI\API\Requests\FindUserByIdRequest;
 use App\Containers\User\UI\API\Requests\GetAllUsersRequest;
 use App\Containers\User\UI\API\Requests\RegisterUserRequest;
+use App\Containers\User\UI\API\Requests\ResetPasswordRequest;
 use App\Containers\User\UI\API\Requests\UpdateUserRequest;
 use App\Containers\User\UI\API\Transformers\UserTransformer;
 use App\Ship\Parents\Controllers\ApiController;
@@ -127,6 +129,26 @@ class Controller extends ApiController
         $user = Apiato::call('User@GetAuthenticatedUserAction', [$request]);
 
         return $this->transform($user, UserTransformer::class, ['roles']);
+    }
+
+    /**
+     * @param ResetPasswordRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function resetPassword(ResetPasswordRequest $request) {
+        Apiato::call('User@ResetPasswordAction', [$request]);
+
+        return $this->noContent(204);
+    }
+
+    /**
+     * @param ForgotPasswordRequest $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function forgotPassword(ForgotPasswordRequest $request) {
+        Apiato::call('User@ForgotPasswordAction', [$request]);
+
+        return $this->noContent(202);
     }
 
 }

--- a/app/Containers/User/UI/API/Requests/ForgotPasswordRequest.php
+++ b/app/Containers/User/UI/API/Requests/ForgotPasswordRequest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Containers\User\UI\API\Requests;
+
+use App\Ship\Parents\Requests\Request;
+
+/**
+ * Class ForgotPasswordRequest.
+ */
+class ForgotPasswordRequest extends Request
+{
+    /**
+     * Define which Roles and/or Permissions has access to this request.
+     *
+     * @var  array
+     */
+    protected $access = [
+        'permissions' => '',
+        'roles'       => '',
+    ];
+
+    /**
+     * Id's that needs decoding before applying the validation rules.
+     *
+     * @var  array
+     */
+    protected $decode = [
+        // 'id',
+    ];
+
+    /**
+     * Defining the URL parameters (e.g, `/user/{id}`) allows applying
+     * validation rules on them and allows accessing them like request data.
+     *
+     * @var  array
+     */
+    protected $urlParameters = [
+        // 'id',
+    ];
+
+    /**
+     * @return  array
+     */
+    public function rules()
+    {
+        return [
+            'email' => 'required|email|max:255',
+            'reseturl' => 'required|max:255',
+        ];
+    }
+
+    /**
+     * @return  bool
+     */
+    public function authorize()
+    {
+        return $this->check([
+            'hasAccess',
+        ]);
+    }
+}

--- a/app/Containers/User/UI/API/Requests/ResetPasswordRequest.php
+++ b/app/Containers/User/UI/API/Requests/ResetPasswordRequest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Containers\User\UI\API\Requests;
+
+use App\Ship\Parents\Requests\Request;
+
+/**
+ * Class ResetPasswordRequest.
+ */
+class ResetPasswordRequest extends Request
+{
+    /**
+     * Define which Roles and/or Permissions has access to this request.
+     *
+     * @var  array
+     */
+    protected $access = [
+        'permissions' => '',
+        'roles'       => '',
+    ];
+
+    /**
+     * Id's that needs decoding before applying the validation rules.
+     *
+     * @var  array
+     */
+    protected $decode = [
+        // 'id',
+    ];
+
+    /**
+     * Defining the URL parameters (e.g, `/user/{id}`) allows applying
+     * validation rules on them and allows accessing them like request data.
+     *
+     * @var  array
+     */
+    protected $urlParameters = [
+        // 'id',
+    ];
+
+    /**
+     * @return  array
+     */
+    public function rules()
+    {
+        return [
+            'token' => 'required|max:255',
+            'email' => 'required|email|max:255',
+            'password' => 'required|min:6|max:255',
+        ];
+    }
+
+    /**
+     * @return  bool
+     */
+    public function authorize()
+    {
+        return $this->check([
+            'hasAccess',
+        ]);
+    }
+}

--- a/app/Containers/User/UI/API/Routes/ForgotPassword.v1.public.php
+++ b/app/Containers/User/UI/API/Routes/ForgotPassword.v1.public.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @apiGroup           User
+ * @apiName            forgotPassword
+ *
+ * @api                {POST} /v1/forgotpassword Forgot password
+ * @apiDescription     Forgot password endpoint.
+ *
+ * @apiVersion         1.0.0
+ * @apiPermission      none
+ *
+ * @apiParam           {String}  email (required|email|max:255)
+ * @apiParam           {String}  reseturl (required|max:255)
+ *
+ * @apiSuccessExample  {json}  Success-Response:
+ * HTTP/1.1 204 OK
+{}
+ */
+
+/** @var Route $router */
+$router->post('forgotpassword', [
+    'as' => 'api_user_forgot_password',
+    'uses'  => 'Controller@forgotPassword',
+    'middleware' => [
+    ],
+]);

--- a/app/Containers/User/UI/API/Routes/ResetPassword.v1.public.php
+++ b/app/Containers/User/UI/API/Routes/ResetPassword.v1.public.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @apiGroup           User
+ * @apiName            resetPassword
+ *
+ * @api                {POST} /v1/resetpassword Reset Password
+ * @apiDescription     Resets a password for an user.
+ *
+ * @apiVersion         1.0.0
+ * @apiPermission      none
+ *
+ * @apiParam           {String}  email (required|email|max:255)
+ * @apiParam           {String}  token (required|max:255) from the forgot password email
+ * @apiParam           {String}  password (required|min:6|max:255) the new password
+ *
+ * @apiSuccessExample  {json}  Success-Response:
+ * HTTP/1.1 202 OK
+{}
+ */
+
+/** @var Route $router */
+$router->post('resetpassword', [
+    'as' => 'api_user_reset_password',
+    'uses'  => 'Controller@resetPassword',
+    'middleware' => [
+    ],
+]);


### PR DESCRIPTION
I added 2 public api endpoints `/forgotpassword` and `/resetpassword`.

To keep link generation dynamic (for multiple client applications) I do inject a reseturl variable from the client into the email, which opens an exploit vector since this is an open endpoint. I tried to avoid exploitation by a config variable to hold all allowed reseturls to prevent malicious urls in the email. Not sure if that is the right approach?

I tested this in my own application but haven't been able to provide automated tests. Any hints?

Would these changes invoke changes in the docs and if so how and where?

Thanks, Yal