### PR TITLE
Error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added ValueObjects class type to be extended by classes that do not requires to be stored in the DB or have ID.
 - Added a `level` to the roles in order to indicate some kind of hierarchy (e.g., `admin` is "better" than `manager`).
 - Added `/password-forgot` and `/password-reset` endpoints.
+- Added Error Code Tables (`ApplicationErrorCodesTable` and `CustomErrorCodesTable`) in order to define exception codes in one place.
 
 ### Changed
 - Changed the `Content-Language` header field (for requesting resources in a specific language) to `Accept-Language` instead (cf. [Specs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language)).

--- a/app/Ship/Exceptions/Codes/ApplicationErrorCodes.php
+++ b/app/Ship/Exceptions/Codes/ApplicationErrorCodes.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace App\Ship\Exceptions\Codes;
+
+/**
+ * Class ApplicationErrorCodes
+ *
+ * @author  Johannes Schobel <johannes.schobel@googlemail.com>
+ */
+class ApplicationErrorCodes
+{
+    /**
+     * The Application Errors defined by Apiato
+     * Apiato reserves the error codes 000000 - 099999 for itself.
+     */
+    const BASE_GENERAL_ERROR = [
+        'code' => 1001,
+        'title' => 'An unknown error.',
+        'description' => 'Something unexpected happend.',
+    ];
+    const BASE_INTERNAL_ERROR = [
+        'code' => 1002,
+        'title' => '',
+        'description' => '',
+    ];
+    const BASE_NOT_IMPLEMENTED = [
+        'code' => 1003,
+        'title' => '',
+        'description' => '',
+    ];
+    const BASE_CONTAINER_MISSING = [
+        'code' => 1010,
+        'title' => '',
+        'description' => '',
+    ];
+    const BASE_CLASS_MISSING = [
+        'code' => 1011,
+        'title' => '',
+        'description' => '',
+    ];
+    const BASE_METHOD_MISSING = [
+        'code' => 1012,
+        'title' => '',
+        'description' => '',
+    ];
+    const BASE_CONFIGURATION_GENERAL_ERROR = [
+        'code' => 1020,
+        'title' => '',
+        'description' => '',
+    ];
+    const BASE_CONFIGURATION_WRONG = [
+        'code' => 1021,
+        'title' => '',
+        'description' => '',
+    ];
+    const AUTHENTICATION_GENERAL_ERROR = [
+        'code' => 1100,
+        'title' => '',
+        'description' => '',
+    ];
+    const AUTHENTICATION_NOT_ALLOWED = [
+        'code' => 1101,
+        'title' => '',
+        'description' => '',
+    ];
+    const AUTHENTICATION_INVALID_CREDENTIALS = [
+        'code' => 1102,
+        'title' => '',
+        'description' => '',
+    ];
+    const AUTHENTICATION_TOKEN_ERROR = [
+        'code' => 1110,
+        'title' => '',
+        'description' => '',
+    ];
+    const AUTHENTICATION_TOKEN_EXPIRED = [
+        'code' => 1111,
+        'title' => '',
+        'description' => '',
+    ];
+    const AUTHENTICATION_TOKEN_BLACKLISTED = [
+        'code' => 1112,
+        'title' => '',
+        'description' => '',
+    ];
+    const AUTHORIZATION_FAILED = [
+        'code' => 1120,
+        'title' => '',
+        'description' => '',
+    ];
+    const AUTHORIZATION_NOT_AUTHORIZED = [
+        'code' => 1121,
+        'title' => '',
+        'description' => '',
+    ];
+    const AUTHORIZATION_INSUFFICIENT_ROLE = [
+        'code' => 1122,
+        'title' => '',
+        'description' => '',
+    ];
+    const REQUEST_GENERAL_ERROR = [
+        'code' => 1300,
+        'title' => '',
+        'description' => '',
+    ];
+    const REQUEST_TOKEN_MISSING = [
+        'code' => 1301,
+        'title' => '',
+        'description' => '',
+    ];
+    const REQUEST_TOKEN_EXPIRED = [
+        'code' => 1302,
+        'title' => '',
+        'description' => '',
+    ];
+    const REQUEST_HEADER_JSON_MISSING = [
+        'code' => 1310,
+        'title' => '',
+        'description' => '',
+    ];
+    const RESPONSE_GENERAL_ERROR = [
+        'code' => 1350,
+        'title' => '',
+        'description' => '',
+    ];
+    const RESPONSE_UNSUPPORTED_SERIALIZER = [
+        'code' => 1351,
+        'title' => '',
+        'description' => '',
+    ];
+    const RESPONSE_UNKNOWN_INCLUDE = [
+        'code' => 1352,
+        'title' => '',
+        'description' => '',
+    ];
+    const RESOURCE_GENERAL_ERROR = [
+        'code' => 1400,
+        'title' => '',
+        'description' => '',
+    ];
+    const RESOURCE_CREATE_FAILED = [
+        'code' => 1401,
+        'title' => '',
+        'description' => '',
+    ];
+    const RESOURCE_UPDATE_FAILED = [
+        'code' => 1402,
+        'title' => '',
+        'description' => '',
+    ];
+    const RESOURCE_DELETE_FAILED = [
+        'code' => 1403,
+        'title' => '',
+        'description' => '',
+    ];
+    const RESOURCE_NOT_FOUND = [
+        'code' => 1404,
+        'title' => '',
+        'description' => '',
+    ];
+    const VALIDATION_GENERAL_ERROR = [
+        'code' => 1500,
+        'title' => '',
+        'description' => '',
+    ];
+    const VALIDATION_FAILED = [
+        'code' => 1501,
+        'title' => '',
+        'description' => '',
+    ];
+    const VALIDATION_WRONG_ID = [
+        'code' => 1502,
+        'title' => '',
+        'description' => '',
+    ];
+    const USER_GENERAL_ERROR = [
+        'code' => 1800,
+        'title' => '',
+        'description' => '',
+    ];
+    const USER_ALREADY_EXISTS = [
+        'code' => 1801,
+        'title' => '',
+        'description' => '',
+    ];
+    const USER_ALREADY_VERIFIED = [
+        'code' => 1802,
+        'title' => '',
+        'description' => '',
+    ];
+    const USER_NOT_VERIFIED = [
+        'code' => 1803,
+        'title' => '',
+        'description' => '',
+    ];
+    const TEST_GENERAL_ERROR = [
+        'code' => 1900,
+        'title' => '',
+        'description' => '',
+    ];
+    const TEST_ENDPOINT_MISSING = [
+        'code' => 1901,
+        'title' => '',
+        'description' => '',
+    ];
+
+    /**
+     * Add your custom application error codes here
+     */
+
+
+
+}

--- a/app/Ship/Exceptions/Codes/ApplicationErrorCodes.php
+++ b/app/Ship/Exceptions/Codes/ApplicationErrorCodes.php
@@ -15,43 +15,43 @@ class ApplicationErrorCodes
      */
     const BASE_GENERAL_ERROR = [
         'code' => 1001,
-        'title' => 'An unknown error.',
-        'description' => 'Something unexpected happend.',
+        'title' => 'Unknown / Unspecified Error.',
+        'description' => 'Something unexpected happened.',
     ];
     const BASE_INTERNAL_ERROR = [
         'code' => 1002,
-        'title' => '',
-        'description' => '',
+        'title' => 'Internal Error',
+        'description' => 'An internal error occurred.',
     ];
     const BASE_NOT_IMPLEMENTED = [
         'code' => 1003,
-        'title' => '',
-        'description' => '',
+        'title' => 'Not Implemented',
+        'description' => 'This class, method or route is not implemented.',
     ];
     const BASE_CONTAINER_MISSING = [
         'code' => 1010,
-        'title' => '',
-        'description' => '',
+        'title' => 'Container Missing',
+        'description' => 'The requested container cannot be found.',
     ];
     const BASE_CLASS_MISSING = [
         'code' => 1011,
-        'title' => '',
-        'description' => '',
+        'title' => 'Class Missing',
+        'description' => 'The requested class cannot be found.',
     ];
     const BASE_METHOD_MISSING = [
         'code' => 1012,
-        'title' => '',
-        'description' => '',
+        'title' => 'Method Missing',
+        'description' => 'The requested method cannot be found.',
     ];
     const BASE_CONFIGURATION_GENERAL_ERROR = [
         'code' => 1020,
-        'title' => '',
-        'description' => '',
+        'title' => 'Configuration Error',
+        'description' => 'An unexpected error occurred in the configuration.',
     ];
     const BASE_CONFIGURATION_WRONG = [
         'code' => 1021,
-        'title' => '',
-        'description' => '',
+        'title' => 'Wrong Configuration',
+        'description' => 'A wrong configuration was found.',
     ];
     const AUTHENTICATION_GENERAL_ERROR = [
         'code' => 1100,

--- a/app/Ship/Exceptions/Codes/ApplicationErrorCodesTable.php
+++ b/app/Ship/Exceptions/Codes/ApplicationErrorCodesTable.php
@@ -3,15 +3,19 @@
 namespace App\Ship\Exceptions\Codes;
 
 /**
- * Class ApplicationErrorCodes
+ * Class ApplicationErrorCodesTable
  *
  * @author  Johannes Schobel <johannes.schobel@googlemail.com>
  */
-class ApplicationErrorCodes
+class ApplicationErrorCodesTable
 {
     /**
      * The Application Errors defined by Apiato
      * Apiato reserves the error codes 000000 - 099999 for itself.
+     *
+     * Do not manually change this file, as this will be changed occasionally by Apiato.
+     * If you do like to create your own (custom) error codes, please use the
+     * App\Ship\Exceptions\Codes\CustomErrorCodesTable class and follow the scheme defined in this class here
      */
     const BASE_GENERAL_ERROR = [
         'code' => 1001,
@@ -203,11 +207,4 @@ class ApplicationErrorCodes
         'title' => '',
         'description' => '',
     ];
-
-    /**
-     * Add your custom application error codes here
-     */
-
-
-
 }

--- a/app/Ship/Exceptions/Codes/ApplicationErrorCodesTable.php
+++ b/app/Ship/Exceptions/Codes/ApplicationErrorCodesTable.php
@@ -2,12 +2,14 @@
 
 namespace App\Ship\Exceptions\Codes;
 
+use App\Ship\Parents\Exceptions\ErrorCodesTable;
+
 /**
  * Class ApplicationErrorCodesTable
  *
  * @author  Johannes Schobel <johannes.schobel@googlemail.com>
  */
-class ApplicationErrorCodesTable
+class ApplicationErrorCodesTable extends ErrorCodesTable
 {
     /**
      * The Application Errors defined by Apiato

--- a/app/Ship/Exceptions/Codes/CustomErrorCodesTable.php
+++ b/app/Ship/Exceptions/Codes/CustomErrorCodesTable.php
@@ -2,12 +2,14 @@
 
 namespace App\Ship\Exceptions\Codes;
 
+use App\Ship\Parents\Exceptions\ErrorCodesTable;
+
 /**
  * Class CustomErrorCodesTable
  *
  * @author  Johannes Schobel <johannes.schobel@googlemail.com>
  */
-class CustomErrorCodesTable
+class CustomErrorCodesTable extends ErrorCodesTable
 {
     /**
      * Use this class to define your own custom error code tables. Please follow the scheme defined in the other file

--- a/app/Ship/Exceptions/Codes/CustomErrorCodesTable.php
+++ b/app/Ship/Exceptions/Codes/CustomErrorCodesTable.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Ship\Exceptions\Codes;
+
+/**
+ * Class CustomErrorCodesTable
+ *
+ * @author  Johannes Schobel <johannes.schobel@googlemail.com>
+ */
+class CustomErrorCodesTable
+{
+    /**
+     * Use this class to define your own custom error code tables. Please follow the scheme defined in the other file
+     * in order to make them compliant!
+     *
+     * Please note that Apiato reserves the error codes 000000 - 099999 for itself. If you define your own codes,
+     * please start with 100000
+     *
+     * const BASE_GENERAL_ERROR = [
+     *      'code' => 100000,
+     *      'title' => 'Unknown / Unspecified Error.',
+     *      'description' => 'Something unexpected happened.',
+     *  ];
+     *
+     */
+
+}

--- a/app/Ship/Exceptions/Codes/ErrorCodeManager.php
+++ b/app/Ship/Exceptions/Codes/ErrorCodeManager.php
@@ -17,7 +17,7 @@ class ErrorCodeManager
      *
      * @return mixed
      */
-    public static function _getCode(array $error)
+    public static function getCode(array $error)
     {
         return self::getKeyFromArray($error, 'code', 0);
     }
@@ -27,7 +27,7 @@ class ErrorCodeManager
      *
      * @return mixed
      */
-    public static function _getTitle(array $error)
+    public static function getTitle(array $error)
     {
         return self::getKeyFromArray($error, 'title', '');
     }
@@ -37,7 +37,7 @@ class ErrorCodeManager
      *
      * @return mixed
      */
-    public static function _getDescription(array $error)
+    public static function getDescription(array $error)
     {
         return self::getKeyFromArray($error, 'description', '');
     }

--- a/app/Ship/Exceptions/Codes/ErrorCodeManager.php
+++ b/app/Ship/Exceptions/Codes/ErrorCodeManager.php
@@ -64,7 +64,8 @@ class ErrorCodeManager
     public static function getCodeTables()
     {
         $codeTables = [
-            ApplicationErrorCodes::class,
+            ApplicationErrorCodesTable::class,
+            CustomErrorCodesTable::class,
         ];
 
         return $codeTables;

--- a/app/Ship/Exceptions/Codes/ErrorCodeManager.php
+++ b/app/Ship/Exceptions/Codes/ErrorCodeManager.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Ship\Exceptions\Codes;
+use App\Ship\Exceptions\InternalErrorException;
+use Exception;
+use ReflectionClass;
+
+/**
+ * Class ErrorCodeManager
+ *
+ * @author  Johannes Schobel <johannes.schobel@googlemail.com>
+ */
+class ErrorCodeManager
+{
+    /**
+     * @param array $error
+     *
+     * @return mixed
+     */
+    public static function _getCode(array $error)
+    {
+        return self::getKeyFromArray($error, 'code', 0);
+    }
+
+    /**
+     * @param array $error
+     *
+     * @return mixed
+     */
+    public static function _getTitle(array $error)
+    {
+        return self::getKeyFromArray($error, 'title', '');
+    }
+
+    /**
+     * @param array $error
+     *
+     * @return mixed
+     */
+    public static function _getDescription(array $error)
+    {
+        return self::getKeyFromArray($error, 'description', '');
+    }
+
+    /**
+     * Returns the value for a given key in the array or a default value
+     *
+     * @param array $error
+     * @param       $key
+     * @param       $default
+     *
+     * @return mixed
+     */
+    private static function getKeyFromArray(array $error, $key, $default)
+    {
+        return isset($error[$key]) ? $error[$key] : $default;
+    }
+
+    /**
+     * Returns all "defined" CodeTables
+     *
+     * @return array
+     */
+    public static function getCodeTables()
+    {
+        $codeTables = [
+            ApplicationErrorCodes::class,
+        ];
+
+        return $codeTables;
+    }
+
+    /**
+     * Get all arrays for this one error code table
+     *
+     * @param $codeTable
+     *
+     * @return array
+     * @throws InternalErrorException
+     */
+    public static function getErrorsForCodeTable($codeTable)
+    {
+        try {
+            $class = new $codeTable;
+        }
+        catch (Exception $exception) {
+            throw new InternalErrorException();
+        }
+
+        // now we need to get all errors (i.e., constants) from this class!
+        $reflectionClass = new ReflectionClass($class);
+        $constants = $reflectionClass->getConstants();
+
+        return $constants;
+    }
+
+    /**
+     * Get all errors across all defined error code tables
+     *
+     * @return array
+     */
+    public static function getErrorsForCodeTables()
+    {
+        $tables = self::getCodeTables();
+
+        $result = [];
+
+        foreach ($tables as $table) {
+            $errors = self::getErrorsForCodeTable($table);
+            $result = array_merge($result, $errors);
+        }
+
+        return $result;
+    }
+}

--- a/app/Ship/Parents/Exceptions/ErrorCodesTable.php
+++ b/app/Ship/Parents/Exceptions/ErrorCodesTable.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Ship\Parents\Exceptions;
+
+use Apiato\Core\Abstracts\Exceptions\ErrorCodesTable as AbstractErrorCodesTable;
+
+/**
+ * Class ErrorCodesTable
+ *
+ * @author  Johannes Schobel <johannes.schobel@googlemail.com>
+ */
+abstract class ErrorCodesTable extends AbstractErrorCodesTable
+{
+
+}


### PR DESCRIPTION
This PR offers the possibility to maintain all `codes` for exceptions in one central place. The main idea behind this feature is to re-use these codes to automatically generate the documentation for the API.

Note that this feature is optional and can simply be skipped. If you like to use
```php
public $code = 4711;
```
in your `Exceptions` this is completely fine.

However, if you like to use this feature, simply use
```php
public useErrorCode() {
   return ApplicationErrorCodesTable::YOUR_ERROR_CODE_HERE;
}
```
in order to "link" the error code to this specific exception - and you're done.. 