### PR TITLE
get rid of env() calls

### DIFF
--- a/app/Containers/Authentication/Configs/authentication-container.php
+++ b/app/Containers/Authentication/Configs/authentication-container.php
@@ -14,4 +14,30 @@ return [
   
     'require_email_confirmation' => false,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Clients
+    |--------------------------------------------------------------------------
+    |
+    | A list of clients that have access to the application.
+    |
+    */
+
+    'clients' => [
+        'web' => [
+            'admin' => [
+                'id' => env('CLIENT_WEB_ADMIN_ID'),
+                'secret' => env('CLIENT_WEB_ADMIN_SECRET'),
+            ],
+        ],
+        'mobile' => [
+            'admin' => [
+                'id' => env('CLIENT_MOBILE_ADMIN_ID'),
+                'secret' => env('CLIENT_MOBILE_ADMIN_SECRET'),
+            ],
+        ],
+
+        // add your other clients here
+    ],
+
 ];

--- a/app/Containers/Authentication/UI/API/Controllers/Controller.php
+++ b/app/Containers/Authentication/UI/API/Controllers/Controller.php
@@ -2,12 +2,13 @@
 
 namespace App\Containers\Authentication\UI\API\Controllers;
 
+use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\Authentication\UI\API\Requests\LoginRequest;
 use App\Containers\Authentication\UI\API\Requests\LogoutRequest;
 use App\Containers\Authentication\UI\API\Requests\RefreshRequest;
 use App\Ship\Parents\Controllers\ApiController;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Cookie;
-use Apiato\Core\Foundation\Facades\Apiato;
 
 /**
  * Class Controller
@@ -47,8 +48,8 @@ class Controller extends ApiController
     {
         $result = Apiato::call('Authentication@ProxyApiLoginAction', [
             $request,
-            env('CLIENT_WEB_ADMIN_ID'),
-            env('CLIENT_WEB_ADMIN_SECRET'),
+            Config::get('authentication-container.clients.web.admin.id'),
+            Config::get('authentication-container.clients.web.admin.secret'),
         ]);
 
         return $this->json($result['response-content'])->withCookie($result['refresh-cookie']);
@@ -65,8 +66,8 @@ class Controller extends ApiController
     {
         $result = Apiato::call('Authentication@ProxyApiRefreshAction', [
             $request,
-            env('CLIENT_WEB_ADMIN_ID'),
-            env('CLIENT_WEB_ADMIN_SECRET'),
+            Config::get('authentication-container.clients.web.admin.id'),
+            Config::get('authentication-container.clients.web.admin.secret'),
         ]);
 
         return $this->json($result['response-content'])->withCookie($result['refresh-cookie']);

--- a/app/Containers/Authentication/UI/API/Tests/Functional/ProxyLoginTest.php
+++ b/app/Containers/Authentication/UI/API/Tests/Functional/ProxyLoginTest.php
@@ -3,6 +3,7 @@
 namespace App\Containers\User\UI\API\Tests\Functional;
 
 use App\Containers\Authentication\Tests\TestCase;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -52,8 +53,8 @@ class ProxyLoginTest extends TestCase
         ]);
 
         // make the clients credentials available as env variables
-        putenv('CLIENT_WEB_ADMIN_ID=' . $clientId);
-        putenv('CLIENT_WEB_ADMIN_SECRET=' . $clientSecret);
+        Config::set('authentication-container.clients.web.admin.id', $clientId);
+        Config::set('authentication-container.clients.web.admin.secret', $clientSecret);
 
         // create testing oauth keys files
         $publicFilePath = $this->createTestingKey('oauth-public.key');
@@ -109,8 +110,8 @@ class ProxyLoginTest extends TestCase
         ]);
 
         // make the clients credentials available as env variables
-        putenv('CLIENT_WEB_ADMIN_ID=' . $clientId);
-        putenv('CLIENT_WEB_ADMIN_SECRET=' . $clientSecret);
+        Config::set('authentication-container.clients.web.admin.id', $clientId);
+        Config::set('authentication-container.clients.web.admin.secret', $clientSecret);
 
         // create testing oauth keys files
         $publicFilePath = $this->createTestingKey('oauth-public.key');
@@ -118,7 +119,7 @@ class ProxyLoginTest extends TestCase
 
         $response = $this->endpoint($endpoint)->makeCall($data);
 
-        if (\Config::get('authentication-container.require_email_confirmation')) {
+        if (Config::get('authentication-container.require_email_confirmation')) {
             $response->assertStatus(409);
         } else {
             $response->assertStatus(200);

--- a/app/Containers/User/Mails/Templates/user-forgotPassword.blade.php
+++ b/app/Containers/User/Mails/Templates/user-forgotPassword.blade.php
@@ -6,7 +6,7 @@
 <body>
 <h3>Reset password</h3>
 <div>
-    Please click on the link to reset your password: <a href="{{env('APP_URL')}}/{{$reseturl}}?email={{$email}}&token={{$token}}">{{env('APP_URL')}}/{{$reseturl}}?email={{$email}}&token={{$token}}</a>.
+    Please click on the link to reset your password: <a href="{{config('app.url')}}/{{$reseturl}}?email={{$email}}&token={{$token}}">{{config('app.url')}}/{{$reseturl}}?email={{$email}}&token={{$token}}</a>.
 </div>
 </body>
 </html>


### PR DESCRIPTION
This PR removes some `env()` calls and replaces them with `Config::get()` calls..

See this issue here: https://github.com/apiato/apiato/issues/314
