### PR TITLE
Improve Transporters

### DIFF
--- a/app/Containers/Authentication/Actions/ApiLogoutAction.php
+++ b/app/Containers/Authentication/Actions/ApiLogoutAction.php
@@ -3,7 +3,7 @@
 namespace App\Containers\Authentication\Actions;
 
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\DB;
 use Lcobucci\JWT\Parser;
@@ -17,11 +17,11 @@ class ApiLogoutAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  bool
      */
-    public function run(DataTransporter $data): bool
+    public function run(Transporter $data): bool
     {
         $id = App::make(Parser::class)->parse($data->bearerToken)->getHeader('jti');
 

--- a/app/Containers/Authentication/Actions/WebAdminLoginAction.php
+++ b/app/Containers/Authentication/Actions/WebAdminLoginAction.php
@@ -5,7 +5,7 @@ namespace App\Containers\Authentication\Actions;
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\Authorization\Exceptions\UserNotAdminException;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 use Illuminate\Contracts\Auth\Authenticatable;
 
 /**
@@ -17,11 +17,11 @@ class WebAdminLoginAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \Illuminate\Contracts\Auth\Authenticatable
      */
-    public function run(DataTransporter $data) : Authenticatable
+    public function run(Transporter $data) : Authenticatable
     {
         $user = Apiato::call('Authentication@WebLoginTask',
             [$data->email, $data->password, $data->remember_me ?? false]);

--- a/app/Containers/Authentication/Actions/WebLoginAction.php
+++ b/app/Containers/Authentication/Actions/WebLoginAction.php
@@ -4,7 +4,7 @@ namespace App\Containers\Authentication\Actions;
 
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 use Illuminate\Contracts\Auth\Authenticatable;
 
 /**
@@ -16,11 +16,11 @@ class WebLoginAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \Illuminate\Contracts\Auth\Authenticatable
      */
-    public function run(DataTransporter $data): Authenticatable
+    public function run(Transporter $data): Authenticatable
     {
         $user = Apiato::call('Authentication@WebLoginTask', [$data->email, $data->password, $data->remember]);
 

--- a/app/Containers/Authentication/UI/WEB/Controllers/Controller.php
+++ b/app/Containers/Authentication/UI/WEB/Controllers/Controller.php
@@ -26,9 +26,11 @@ class Controller extends WebController
     }
 
     /**
-     * @return  \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector
+     * @param  \App\Containers\Authentication\UI\WEB\Requests\LogoutRequest $request
+     *
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector
      */
-    public function logoutAdmin(LogoutRequest $equest)
+    public function logoutAdmin(LogoutRequest $request)
     {
         Apiato::call('Authentication@WebLogoutAction');
 

--- a/app/Containers/Authentication/UI/WEB/Controllers/Controller.php
+++ b/app/Containers/Authentication/UI/WEB/Controllers/Controller.php
@@ -44,7 +44,7 @@ class Controller extends WebController
     public function loginAdmin(LoginRequest $request)
     {
         try {
-            $result = Apiato::call('Authentication@WebAdminLoginAction', [new DataTransporter($request)]);
+            $result = Apiato::call('Authentication@WebAdminLoginAction', [$request->toTransporter()]);
         } catch (Exception $e) {
             return redirect('login')->with('status', $e->getMessage());
         }

--- a/app/Containers/Authentication/UI/WEB/Controllers/Controller.php
+++ b/app/Containers/Authentication/UI/WEB/Controllers/Controller.php
@@ -7,7 +7,6 @@ use App\Containers\Authentication\UI\WEB\Requests\LoginRequest;
 use App\Containers\Authentication\UI\WEB\Requests\LogoutRequest;
 use App\Containers\Authentication\UI\WEB\Requests\ViewDashboardRequest;
 use App\Ship\Parents\Controllers\WebController;
-use App\Ship\Transporters\DataTransporter;
 use Exception;
 
 /**

--- a/app/Containers/Authorization/Actions/AssignUserToRoleAction.php
+++ b/app/Containers/Authorization/Actions/AssignUserToRoleAction.php
@@ -5,7 +5,7 @@ namespace App\Containers\Authorization\Actions;
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\User\Models\User;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class AssignUserToRoleAction.
@@ -16,11 +16,11 @@ class AssignUserToRoleAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \App\Containers\User\Models\User
      */
-    public function run(DataTransporter $data): User
+    public function run(Transporter $data): User
     {
         $user = Apiato::call('User@FindUserByIdTask', [$data->user_id]);
 

--- a/app/Containers/Authorization/Actions/AttachPermissionsToRoleAction.php
+++ b/app/Containers/Authorization/Actions/AttachPermissionsToRoleAction.php
@@ -5,7 +5,7 @@ namespace App\Containers\Authorization\Actions;
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\Authorization\Models\Role;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class AttachPermissionsToRoleAction.
@@ -16,11 +16,11 @@ class AttachPermissionsToRoleAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \App\Containers\Authorization\Models\Role
      */
-    public function run(DataTransporter $data): Role
+    public function run(Transporter $data): Role
     {
         $role = Apiato::call('Authorization@FindRoleTask', [$data->role_id]);
 

--- a/app/Containers/Authorization/Actions/CreatePermissionAction.php
+++ b/app/Containers/Authorization/Actions/CreatePermissionAction.php
@@ -5,7 +5,7 @@ namespace App\Containers\Authorization\Actions;
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\Authorization\Models\Permission;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class CreatePermissionAction
@@ -16,11 +16,11 @@ class CreatePermissionAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \App\Containers\Authorization\Models\Permission
      */
-    public function run(DataTransporter $data): Permission
+    public function run(Transporter $data): Permission
     {
         $permission = Apiato::call('Authorization@CreatePermissionTask',
             [$data->name, $data->description, $data->display_name]

--- a/app/Containers/Authorization/Actions/CreateRoleAction.php
+++ b/app/Containers/Authorization/Actions/CreateRoleAction.php
@@ -5,7 +5,7 @@ namespace App\Containers\Authorization\Actions;
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\Authorization\Models\Role;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 use function is_null;
 
 /**
@@ -17,11 +17,11 @@ class CreateRoleAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \App\Containers\Authorization\Models\Role
      */
-    public function run(DataTransporter $data): Role
+    public function run(Transporter $data): Role
     {
         $level = is_null($data->level) ? 0 : $data->level ;
 

--- a/app/Containers/Authorization/Actions/DeleteRoleAction.php
+++ b/app/Containers/Authorization/Actions/DeleteRoleAction.php
@@ -4,7 +4,7 @@ namespace App\Containers\Authorization\Actions;
 
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 use Spatie\Permission\Contracts\Role;
 
 /**
@@ -16,11 +16,11 @@ class DeleteRoleAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \Spatie\Permission\Contracts\Role
      */
-    public function run(DataTransporter $data): Role
+    public function run(Transporter $data): Role
     {
         $role = Apiato::call('Authorization@FindRoleTask', [$data->id]);
 

--- a/app/Containers/Authorization/Actions/DetachPermissionsFromRoleAction.php
+++ b/app/Containers/Authorization/Actions/DetachPermissionsFromRoleAction.php
@@ -5,7 +5,7 @@ namespace App\Containers\Authorization\Actions;
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\Authorization\Models\Role;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class DetachPermissionsFromRoleAction.
@@ -16,11 +16,11 @@ class DetachPermissionsFromRoleAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \App\Containers\Authorization\Models\Role
      */
-    public function run(DataTransporter $data): Role
+    public function run(Transporter $data): Role
     {
         $role = Apiato::call('Authorization@FindRoleTask', [$data->role_id]);
 

--- a/app/Containers/Authorization/Actions/FindPermissionAction.php
+++ b/app/Containers/Authorization/Actions/FindPermissionAction.php
@@ -6,7 +6,7 @@ use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\Authorization\Exceptions\PermissionNotFoundException;
 use App\Containers\Authorization\Models\Permission;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class FindPermissionAction.
@@ -17,11 +17,11 @@ class FindPermissionAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \App\Containers\Authorization\Models\Permission
      */
-    public function run(DataTransporter $data): Permission
+    public function run(Transporter $data): Permission
     {
         $permission = Apiato::call('Authorization@FindPermissionTask', [$data->id]);
 

--- a/app/Containers/Authorization/Actions/FindRoleAction.php
+++ b/app/Containers/Authorization/Actions/FindRoleAction.php
@@ -6,7 +6,7 @@ use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\Authorization\Exceptions\RoleNotFoundException;
 use App\Containers\Authorization\Models\Role;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class FindRoleAction.
@@ -17,11 +17,11 @@ class FindRoleAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \App\Containers\Authorization\Models\Role
      */
-    public function run(DataTransporter $data): Role
+    public function run(Transporter $data): Role
     {
         $role = Apiato::call('Authorization@FindRoleTask', [$data->id]);
 

--- a/app/Containers/Authorization/Actions/RevokeUserFromRoleAction.php
+++ b/app/Containers/Authorization/Actions/RevokeUserFromRoleAction.php
@@ -5,7 +5,7 @@ namespace App\Containers\Authorization\Actions;
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\User\Models\User;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 use Illuminate\Database\Eloquent\Collection;
 
 /**
@@ -17,11 +17,11 @@ class RevokeUserFromRoleAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \App\Containers\User\Models\User
      */
-    public function run(DataTransporter $data): User
+    public function run(Transporter $data): User
     {
         // if user ID is passed then convert it to instance of User (could be user Id Or Model)
         if (!$data->user_id instanceof User) {

--- a/app/Containers/Authorization/Actions/SyncPermissionsOnRoleAction.php
+++ b/app/Containers/Authorization/Actions/SyncPermissionsOnRoleAction.php
@@ -5,7 +5,7 @@ namespace App\Containers\Authorization\Actions;
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\Authorization\Models\Role;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class SyncPermissionsOnRoleAction.
@@ -16,11 +16,11 @@ class SyncPermissionsOnRoleAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \App\Containers\Authorization\Models\Role
      */
-    public function run(DataTransporter $data): Role
+    public function run(Transporter $data): Role
     {
         $role = Apiato::call('Authorization@FindRoleTask', [$data->role_id]);
 

--- a/app/Containers/Authorization/Actions/SyncUserRolesAction.php
+++ b/app/Containers/Authorization/Actions/SyncUserRolesAction.php
@@ -5,7 +5,7 @@ namespace App\Containers\Authorization\Actions;
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\User\Models\User;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class SyncUserRolesAction.
@@ -16,11 +16,11 @@ class SyncUserRolesAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \App\Containers\User\Models\User
      */
-    public function run(DataTransporter $data): User
+    public function run(Transporter $data): User
     {
         $user = Apiato::call('User@FindUserByIdTask', [$data->user_id]);
 

--- a/app/Containers/Authorization/UI/API/Controllers/Controller.php
+++ b/app/Containers/Authorization/UI/API/Controllers/Controller.php
@@ -48,7 +48,7 @@ class Controller extends ApiController
      */
     public function findPermission(FindPermissionRequest $request)
     {
-        $permission = Apiato::call('Authorization@FindPermissionAction', [new DataTransporter($request)]);
+        $permission = Apiato::call('Authorization@FindPermissionAction', [$request->toTransporter()]);
 
         return $this->transform($permission, PermissionTransformer::class);
     }
@@ -72,7 +72,7 @@ class Controller extends ApiController
      */
     public function findRole(FindRoleRequest $request)
     {
-        $role = Apiato::call('Authorization@FindRoleAction', [new DataTransporter($request)]);
+        $role = Apiato::call('Authorization@FindRoleAction', [$request->toTransporter()]);
 
         return $this->transform($role, RoleTransformer::class);
     }
@@ -84,7 +84,7 @@ class Controller extends ApiController
      */
     public function assignUserToRole(AssignUserToRoleRequest $request)
     {
-        $user = Apiato::call('Authorization@AssignUserToRoleAction', [new DataTransporter($request)]);
+        $user = Apiato::call('Authorization@AssignUserToRoleAction', [$request->toTransporter()]);
 
         return $this->transform($user, UserTransformer::class);
     }
@@ -96,7 +96,7 @@ class Controller extends ApiController
      */
     public function syncUserRoles(SyncUserRolesRequest $request)
     {
-        $user = Apiato::call('Authorization@SyncUserRolesAction', [new DataTransporter($request)]);
+        $user = Apiato::call('Authorization@SyncUserRolesAction', [$request->toTransporter()]);
 
         return $this->transform($user, UserTransformer::class);
     }
@@ -108,7 +108,7 @@ class Controller extends ApiController
      */
     public function deleteRole(DeleteRoleRequest $request)
     {
-        Apiato::call('Authorization@DeleteRoleAction', [new DataTransporter($request)]);
+        Apiato::call('Authorization@DeleteRoleAction', [$request->toTransporter()]);
 
         return $this->noContent();
     }
@@ -120,7 +120,7 @@ class Controller extends ApiController
      */
     public function revokeRoleFromUser(RevokeUserFromRoleRequest $request)
     {
-        $user = Apiato::call('Authorization@RevokeUserFromRoleAction', [new DataTransporter($request)]);
+        $user = Apiato::call('Authorization@RevokeUserFromRoleAction', [$request->toTransporter()]);
 
         return $this->transform($user, UserTransformer::class);
     }
@@ -132,7 +132,7 @@ class Controller extends ApiController
      */
     public function attachPermissionToRole(AttachPermissionToRoleRequest $request)
     {
-        $role = Apiato::call('Authorization@AttachPermissionsToRoleAction', [new DataTransporter($request)]);
+        $role = Apiato::call('Authorization@AttachPermissionsToRoleAction', [$request->toTransporter()]);
 
         return $this->transform($role, RoleTransformer::class);
     }
@@ -144,7 +144,7 @@ class Controller extends ApiController
      */
     public function syncPermissionOnRole(SyncPermissionsOnRoleRequest $request)
     {
-        $role = Apiato::call('Authorization@SyncPermissionsOnRoleAction', [new DataTransporter($request)]);
+        $role = Apiato::call('Authorization@SyncPermissionsOnRoleAction', [$request->toTransporter()]);
 
         return $this->transform($role, RoleTransformer::class);
     }
@@ -156,7 +156,7 @@ class Controller extends ApiController
      */
     public function detachPermissionFromRole(DetachPermissionToRoleRequest $request)
     {
-        $role = Apiato::call('Authorization@DetachPermissionsFromRoleAction', [new DataTransporter($request)]);
+        $role = Apiato::call('Authorization@DetachPermissionsFromRoleAction', [$request->toTransporter()]);
 
         return $this->transform($role, RoleTransformer::class);
     }
@@ -168,7 +168,7 @@ class Controller extends ApiController
      */
     public function createRole(CreateRoleRequest $request)
     {
-        $role = Apiato::call('Authorization@CreateRoleAction', [new DataTransporter($request)]);
+        $role = Apiato::call('Authorization@CreateRoleAction', [$request->toTransporter()]);
 
         return $this->transform($role, RoleTransformer::class);
     }

--- a/app/Containers/Authorization/UI/API/Controllers/Controller.php
+++ b/app/Containers/Authorization/UI/API/Controllers/Controller.php
@@ -19,7 +19,6 @@ use App\Containers\Authorization\UI\API\Transformers\PermissionTransformer;
 use App\Containers\Authorization\UI\API\Transformers\RoleTransformer;
 use App\Containers\User\UI\API\Transformers\UserTransformer;
 use App\Ship\Parents\Controllers\ApiController;
-use App\Ship\Transporters\DataTransporter;
 
 /**
  * Class Controller.

--- a/app/Containers/Debugger/Values/RequestsLogger.php
+++ b/app/Containers/Debugger/Values/RequestsLogger.php
@@ -37,7 +37,7 @@ class RequestsLogger extends Value
     }
 
     /**
-     * @param \App\Containers\Debugger\Value\Output $output
+     * @param \App\Containers\Debugger\Values\Output $output
      */
     public function releaseOutput(Output $output)
     {

--- a/app/Containers/Documentation/Actions/GenerateDocumentationAction.php
+++ b/app/Containers/Documentation/Actions/GenerateDocumentationAction.php
@@ -4,7 +4,7 @@ namespace App\Containers\Documentation\Actions;
 
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class GenerateDocumentationAction.
@@ -15,9 +15,9 @@ class GenerateDocumentationAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      */
-    public function run(DataTransporter $data): void
+    public function run(Transporter $data): void
     {
         $console = $data->command_instance;
 

--- a/app/Containers/Documentation/UI/CLI/Commands/GenerateApiDocsCommand.php
+++ b/app/Containers/Documentation/UI/CLI/Commands/GenerateApiDocsCommand.php
@@ -4,7 +4,7 @@ namespace App\Containers\Documentation\UI\CLI\Commands;
 
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Ship\Parents\Commands\ConsoleCommand;
-use App\Ship\Parents\Transporters\Transporter;
+use App\Ship\Transporters\DataTransporter;
 
 /**
  * Class GenerateApiDocsCommand
@@ -30,8 +30,6 @@ class GenerateApiDocsCommand extends ConsoleCommand
 
     /**
      * Create a new command instance.
-     *
-     * @return void
      */
     public function __construct()
     {

--- a/app/Containers/Documentation/UI/CLI/Commands/GenerateApiDocsCommand.php
+++ b/app/Containers/Documentation/UI/CLI/Commands/GenerateApiDocsCommand.php
@@ -4,7 +4,7 @@ namespace App\Containers\Documentation\UI\CLI\Commands;
 
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Ship\Parents\Commands\ConsoleCommand;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class GenerateApiDocsCommand

--- a/app/Containers/Localization/Actions/GetAllLocalizationsAction.php
+++ b/app/Containers/Localization/Actions/GetAllLocalizationsAction.php
@@ -2,8 +2,8 @@
 
 namespace App\Containers\Localization\Actions;
 
-use App\Ship\Parents\Actions\Action;
 use Apiato\Core\Foundation\Facades\Apiato;
+use App\Ship\Parents\Actions\Action;
 use Illuminate\Support\Collection;
 
 /**

--- a/app/Containers/Payment/Actions/DeletePaymentAccountAction.php
+++ b/app/Containers/Payment/Actions/DeletePaymentAccountAction.php
@@ -4,7 +4,7 @@ namespace App\Containers\Payment\Actions;
 
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class DeletePaymentAccountAction
@@ -15,9 +15,9 @@ class DeletePaymentAccountAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      */
-    public function run(DataTransporter $data): void
+    public function run(Transporter $data): void
     {
         $user = Apiato::call('Authentication@GetAuthenticatedUserTask');
 

--- a/app/Containers/Payment/Actions/FindPaymentAccountDetailsAction.php
+++ b/app/Containers/Payment/Actions/FindPaymentAccountDetailsAction.php
@@ -5,7 +5,7 @@ namespace App\Containers\Payment\Actions;
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\Payment\Models\PaymentAccount;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class FindPaymentAccountDetailsAction
@@ -16,11 +16,11 @@ class FindPaymentAccountDetailsAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \App\Containers\Payment\Models\PaymentAccount
      */
-    public function run(DataTransporter $data): PaymentAccount
+    public function run(Transporter $data): PaymentAccount
     {
         $user = Apiato::call('Authentication@GetAuthenticatedUserTask');
 

--- a/app/Containers/Payment/Actions/UpdatePaymentAccountAction.php
+++ b/app/Containers/Payment/Actions/UpdatePaymentAccountAction.php
@@ -5,7 +5,7 @@ namespace App\Containers\Payment\Actions;
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\Payment\Models\PaymentAccount;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class UpdatePaymentAccountAction
@@ -17,11 +17,11 @@ class UpdatePaymentAccountAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \App\Containers\Payment\Models\PaymentAccount
      */
-    public function run(DataTransporter $data): PaymentAccount
+    public function run(Transporter $data): PaymentAccount
     {
         $user = Apiato::call('Authentication@GetAuthenticatedUserTask');
 

--- a/app/Containers/Payment/UI/API/Controllers/Controller.php
+++ b/app/Containers/Payment/UI/API/Controllers/Controller.php
@@ -39,7 +39,7 @@ class Controller extends ApiController
      */
     public function getPaymentAccount(FindPaymentAccountRequest $request)
     {
-        $paymentAccount = Apiato::call('Payment@FindPaymentAccountDetailsAction', [new DataTransporter($request)]);
+        $paymentAccount = Apiato::call('Payment@FindPaymentAccountDetailsAction', [$request->toTransporter()]);
 
         return $this->transform($paymentAccount, PaymentAccountTransformer::class);
     }
@@ -51,7 +51,7 @@ class Controller extends ApiController
      */
     public function updatePaymentAccount(UpdatePaymentAccountRequest $request)
     {
-        $paymentAccount = Apiato::call('Payment@UpdatePaymentAccountAction', [new DataTransporter($request)]);
+        $paymentAccount = Apiato::call('Payment@UpdatePaymentAccountAction', [$request->toTransporter()]);
 
         return $this->transform($paymentAccount, PaymentAccountTransformer::class);
     }
@@ -63,7 +63,7 @@ class Controller extends ApiController
      */
     public function deletePaymentAccount(DeletePaymentAccountRequest $request)
     {
-        Apiato::call('Payment@DeletePaymentAccountAction', [new DataTransporter($request)]);
+        Apiato::call('Payment@DeletePaymentAccountAction', [$request->toTransporter()]);
 
         return $this->noContent();
     }

--- a/app/Containers/Payment/UI/API/Controllers/Controller.php
+++ b/app/Containers/Payment/UI/API/Controllers/Controller.php
@@ -9,7 +9,6 @@ use App\Containers\Payment\UI\API\Requests\GetAllPaymentAccountsRequest;
 use App\Containers\Payment\UI\API\Requests\UpdatePaymentAccountRequest;
 use App\Containers\Payment\UI\API\Transformers\PaymentAccountTransformer;
 use App\Ship\Parents\Controllers\ApiController;
-use App\Ship\Transporters\DataTransporter;
 
 /**
  * Class Controller

--- a/app/Containers/Settings/Actions/CreateSettingAction.php
+++ b/app/Containers/Settings/Actions/CreateSettingAction.php
@@ -5,7 +5,7 @@ namespace App\Containers\Settings\Actions;
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\Settings\Models\Setting;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class CreateSettingAction
@@ -16,11 +16,11 @@ class CreateSettingAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \App\Containers\Settings\Models\Setting
      */
-    public function run(DataTransporter $data): Setting
+    public function run(Transporter $data): Setting
     {
         $data = $data->sanitizeInput([
             'key',

--- a/app/Containers/Settings/Actions/DeleteSettingAction.php
+++ b/app/Containers/Settings/Actions/DeleteSettingAction.php
@@ -4,7 +4,7 @@ namespace App\Containers\Settings\Actions;
 
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class DeleteSettingAction
@@ -15,9 +15,9 @@ class DeleteSettingAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      */
-    public function run(DataTransporter $data): void
+    public function run(Transporter $data): void
     {
         $setting = Apiato::call('Settings@FindSettingByIdTask', [$data->id]);
 

--- a/app/Containers/Settings/Actions/UpdateSettingAction.php
+++ b/app/Containers/Settings/Actions/UpdateSettingAction.php
@@ -4,7 +4,7 @@ namespace App\Containers\Settings\Actions;
 
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class UpdateSettingAction
@@ -15,11 +15,11 @@ class UpdateSettingAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  mixed
      */
-    public function run(DataTransporter $data)
+    public function run(Transporter $data)
     {
         $sanitizedData = $data->sanitizeInput([
             'key',

--- a/app/Containers/Settings/UI/API/Controllers/Controller.php
+++ b/app/Containers/Settings/UI/API/Controllers/Controller.php
@@ -42,7 +42,7 @@ class Controller extends ApiController
      */
     public function createSetting(CreateSettingRequest $request)
     {
-        $setting = Apiato::call('Settings@CreateSettingAction', [new DataTransporter($request)]);
+        $setting = Apiato::call('Settings@CreateSettingAction', [$request->toTransporter()]);
 
         return $this->transform($setting, SettingTransformer::class);
     }
@@ -56,7 +56,7 @@ class Controller extends ApiController
      */
     public function updateSetting(UpdateSettingRequest $request)
     {
-        $setting = Apiato::call('Settings@UpdateSettingAction', [new DataTransporter($request)]);
+        $setting = Apiato::call('Settings@UpdateSettingAction', [$request->toTransporter()]);
 
         return $this->transform($setting, SettingTransformer::class);
     }
@@ -70,7 +70,7 @@ class Controller extends ApiController
      */
     public function deleteSetting(DeleteSettingRequest $request)
     {
-        Apiato::call('Settings@DeleteSettingAction', [new DataTransporter($request)]);
+        Apiato::call('Settings@DeleteSettingAction', [$request->toTransporter()]);
 
         return $this->noContent();
     }

--- a/app/Containers/Settings/UI/API/Controllers/Controller.php
+++ b/app/Containers/Settings/UI/API/Controllers/Controller.php
@@ -9,7 +9,6 @@ use App\Containers\Settings\UI\API\Requests\GetAllSettingsRequest;
 use App\Containers\Settings\UI\API\Requests\UpdateSettingRequest;
 use App\Containers\Settings\UI\API\Transformers\SettingTransformer;
 use App\Ship\Parents\Controllers\ApiController;
-use App\Ship\Transporters\DataTransporter;
 
 /**
  * Class Controller

--- a/app/Containers/Socialauth/Actions/SocialLoginAction.php
+++ b/app/Containers/Socialauth/Actions/SocialLoginAction.php
@@ -4,7 +4,7 @@ namespace App\Containers\SocialAuth\Actions;
 
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class SocialLoginAction.
@@ -20,12 +20,12 @@ class SocialLoginAction extends Action
      * ----- if has no social profile
      * --------- [C] create new record
      *
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  mixed
      * @throws \Dto\Exceptions\InvalidDataTypeException
      */
-    public function run(DataTransporter $data)
+    public function run(Transporter $data)
     {
         // fetch the user data from the support platforms
         $socialUserProfile = Apiato::call('Socialauth@FindUserSocialProfileTask', [$data->provider, $data->toArray()]);

--- a/app/Containers/Stripe/Actions/CreateStripeAccountAction.php
+++ b/app/Containers/Stripe/Actions/CreateStripeAccountAction.php
@@ -4,7 +4,7 @@ namespace App\Containers\Stripe\Actions;
 
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class CreateStripeAccountAction.
@@ -15,11 +15,11 @@ class CreateStripeAccountAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  mixed
      */
-    public function run(DataTransporter $data)
+    public function run(Transporter $data)
     {
         $user = Apiato::call('Authentication@GetAuthenticatedUserTask');
 

--- a/app/Containers/Stripe/Actions/UpdateStripeAccountAction.php
+++ b/app/Containers/Stripe/Actions/UpdateStripeAccountAction.php
@@ -5,7 +5,7 @@ namespace App\Containers\Stripe\Actions;
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\Stripe\Models\StripeAccount;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class UpdateStripeAccountAction
@@ -16,11 +16,11 @@ class UpdateStripeAccountAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \App\Containers\Stripe\Models\StripeAccount
      */
-    public function run(DataTransporter $data): StripeAccount
+    public function run(Transporter $data): StripeAccount
     {
         $user = Apiato::call('Authentication@GetAuthenticatedUserTask');
 

--- a/app/Containers/Stripe/UI/API/Controllers/Controller.php
+++ b/app/Containers/Stripe/UI/API/Controllers/Controller.php
@@ -6,7 +6,6 @@ use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\Stripe\UI\API\Requests\CreateStripeAccountRequest;
 use App\Containers\Stripe\UI\API\Requests\UpdateStripeAccountRequest;
 use App\Ship\Parents\Controllers\ApiController;
-use App\Ship\Transporters\DataTransporter;
 
 /**
  * Class Controller.

--- a/app/Containers/Stripe/UI/API/Controllers/Controller.php
+++ b/app/Containers/Stripe/UI/API/Controllers/Controller.php
@@ -23,7 +23,7 @@ class Controller extends ApiController
      */
     public function createStripeAccount(CreateStripeAccountRequest $request)
     {
-        $stripeAccount = Apiato::call('Stripe@CreateStripeAccountAction', [new DataTransporter($request)]);
+        $stripeAccount = Apiato::call('Stripe@CreateStripeAccountAction', [$request->toTransporter()]);
 
         return $this->accepted([
             'message'           => 'Stripe account created successfully.',
@@ -38,7 +38,7 @@ class Controller extends ApiController
      */
     public function updateStripeAccount(UpdateStripeAccountRequest $request)
     {
-        $stripeAccount = Apiato::call('Stripe@UpdateStripeAccountAction', [new DataTransporter($request)]);
+        $stripeAccount = Apiato::call('Stripe@UpdateStripeAccountAction', [$request->toTransporter()]);
 
         return $this->accepted([
             'message'           => 'Stripe account updated successfully.',

--- a/app/Containers/User/Actions/CreateAdminAction.php
+++ b/app/Containers/User/Actions/CreateAdminAction.php
@@ -5,7 +5,7 @@ namespace App\Containers\User\Actions;
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\User\Models\User;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class CreateAdminAction.
@@ -16,11 +16,11 @@ class CreateAdminAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \App\Containers\User\Models\User
      */
-    public function run(DataTransporter $data): User
+    public function run(Transporter $data): User
     {
         $admin = Apiato::call('User@CreateUserByCredentialsTask', [
             $isClient = false,

--- a/app/Containers/User/Actions/DeleteUserAction.php
+++ b/app/Containers/User/Actions/DeleteUserAction.php
@@ -4,7 +4,7 @@ namespace App\Containers\User\Actions;
 
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class DeleteUserAction.
@@ -15,9 +15,9 @@ class DeleteUserAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      */
-    public function run(DataTransporter $data): void
+    public function run(Transporter $data): void
     {
         $user = $data->id ?
             Apiato::call('User@FindUserByIdTask',

--- a/app/Containers/User/Actions/FindUserByIdAction.php
+++ b/app/Containers/User/Actions/FindUserByIdAction.php
@@ -6,7 +6,7 @@ use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\User\Models\User;
 use App\Ship\Exceptions\NotFoundException;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 
 /**
  * Class FindUserByIdAction.
@@ -17,11 +17,11 @@ class FindUserByIdAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \App\Containers\User\Models\User
      */
-    public function run(DataTransporter $data): User
+    public function run(Transporter $data): User
     {
         $user = Apiato::call('User@FindUserByIdTask', [$data->id]);
 

--- a/app/Containers/User/Actions/ForgotPasswordAction.php
+++ b/app/Containers/User/Actions/ForgotPasswordAction.php
@@ -6,7 +6,7 @@ use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\User\Mails\UserForgotPasswordMail;
 use App\Ship\Exceptions\NotFoundException;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 use Illuminate\Support\Facades\Mail;
 
 /**
@@ -19,9 +19,9 @@ class ForgotPasswordAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      */
-    public function run(DataTransporter $data): void
+    public function run(Transporter $data): void
     {
         $user = Apiato::call('User@FindUserByEmailTask', [$data->email]);
 

--- a/app/Containers/User/Actions/RegisterUserAction.php
+++ b/app/Containers/User/Actions/RegisterUserAction.php
@@ -8,7 +8,7 @@ use App\Containers\User\Mails\UserRegisteredMail;
 use App\Containers\User\Models\User;
 use App\Containers\User\Notifications\UserRegisteredNotification;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Mail;
@@ -23,11 +23,11 @@ class RegisterUserAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \App\Containers\User\Models\User
      */
-    public function run(DataTransporter $data): User
+    public function run(Transporter $data): User
     {
         // create user record in the database and return it.
         $user = Apiato::call('User@CreateUserByCredentialsTask', [

--- a/app/Containers/User/Actions/ResetPasswordAction.php
+++ b/app/Containers/User/Actions/ResetPasswordAction.php
@@ -5,7 +5,7 @@ namespace App\Containers\User\Actions;
 use App\Ship\Exceptions\InternalErrorException;
 use App\Ship\Parents\Actions\Action;
 use App\Ship\Parents\Exceptions\Exception;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Support\Str;
@@ -19,9 +19,9 @@ class ResetPasswordAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      */
-    public function run(DataTransporter $data): void
+    public function run(Transporter $data): void
     {
         $data = [
             'email'                 => $data->email,

--- a/app/Containers/User/Actions/UpdateUserAction.php
+++ b/app/Containers/User/Actions/UpdateUserAction.php
@@ -5,7 +5,7 @@ namespace App\Containers\User\Actions;
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\User\Models\User;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 use Illuminate\Support\Facades\Hash;
 
 /**
@@ -17,11 +17,11 @@ class UpdateUserAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \App\Containers\User\Models\User
      */
-    public function run(DataTransporter $data): User
+    public function run(Transporter $data): User
     {
         $userData = [
             'password'             => $data->password ? Hash::make($data->password) : null,

--- a/app/Containers/User/Tests/Unit/RegisterUserTest.php
+++ b/app/Containers/User/Tests/Unit/RegisterUserTest.php
@@ -5,8 +5,7 @@ namespace App\Containers\User\Tests\Unit;
 use App\Containers\User\Actions\RegisterUserAction;
 use App\Containers\User\Models\User;
 use App\Containers\User\Tests\TestCase;
-use App\Containers\User\UI\API\Requests\RegisterUserRequest;
-use App\Ship\Parents\Transporters\Transporter;
+use App\Ship\Transporters\DataTransporter;
 use Illuminate\Support\Facades\App;
 
 /**

--- a/app/Containers/User/Tests/Unit/RegisterUserTest.php
+++ b/app/Containers/User/Tests/Unit/RegisterUserTest.php
@@ -6,7 +6,7 @@ use App\Containers\User\Actions\RegisterUserAction;
 use App\Containers\User\Models\User;
 use App\Containers\User\Tests\TestCase;
 use App\Containers\User\UI\API\Requests\RegisterUserRequest;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 use Illuminate\Support\Facades\App;
 
 /**

--- a/app/Containers/User/UI/API/Controllers/Controller.php
+++ b/app/Containers/User/UI/API/Controllers/Controller.php
@@ -15,7 +15,6 @@ use App\Containers\User\UI\API\Requests\UpdateUserRequest;
 use App\Containers\User\UI\API\Transformers\UserPrivateProfileTransformer;
 use App\Containers\User\UI\API\Transformers\UserTransformer;
 use App\Ship\Parents\Controllers\ApiController;
-use App\Ship\Transporters\DataTransporter;
 
 /**
  * Class Controller.

--- a/app/Containers/User/UI/API/Controllers/Controller.php
+++ b/app/Containers/User/UI/API/Controllers/Controller.php
@@ -32,7 +32,7 @@ class Controller extends ApiController
      */
     public function registerUser(RegisterUserRequest $request)
     {
-        $user = Apiato::call('User@RegisterUserAction', [new DataTransporter($request)]);
+        $user = Apiato::call('User@RegisterUserAction', [$request->toTransporter()]);
 
         return $this->transform($user, UserTransformer::class);
     }
@@ -44,7 +44,7 @@ class Controller extends ApiController
      */
     public function createAdmin(CreateAdminRequest $request)
     {
-        $admin = Apiato::call('User@CreateAdminAction', [new DataTransporter($request)]);
+        $admin = Apiato::call('User@CreateAdminAction', [$request->toTransporter()]);
 
         return $this->transform($admin, UserTransformer::class);
     }
@@ -56,7 +56,7 @@ class Controller extends ApiController
      */
     public function updateUser(UpdateUserRequest $request)
     {
-        $user = Apiato::call('User@UpdateUserAction', [new DataTransporter($request)]);
+        $user = Apiato::call('User@UpdateUserAction', [$request->toTransporter()]);
 
         return $this->transform($user, UserTransformer::class);
     }
@@ -68,7 +68,7 @@ class Controller extends ApiController
      */
     public function deleteUser(DeleteUserRequest $request)
     {
-        Apiato::call('User@DeleteUserAction', [new DataTransporter($request)]);
+        Apiato::call('User@DeleteUserAction', [$request->toTransporter()]);
 
         return $this->noContent();
     }
@@ -116,7 +116,7 @@ class Controller extends ApiController
      */
     public function findUserById(FindUserByIdRequest $request)
     {
-        $user = Apiato::call('User@FindUserByIdAction', [new DataTransporter($request)]);
+        $user = Apiato::call('User@FindUserByIdAction', [$request->toTransporter()]);
 
         return $this->transform($user, UserTransformer::class);
     }
@@ -140,7 +140,7 @@ class Controller extends ApiController
      */
     public function resetPassword(ResetPasswordRequest $request)
     {
-        Apiato::call('User@ResetPasswordAction', [new DataTransporter($request)]);
+        Apiato::call('User@ResetPasswordAction', [$request->toTransporter()]);
 
         return $this->noContent(204);
     }
@@ -152,7 +152,7 @@ class Controller extends ApiController
      */
     public function forgotPassword(ForgotPasswordRequest $request)
     {
-        Apiato::call('User@ForgotPasswordAction', [new DataTransporter($request)]);
+        Apiato::call('User@ForgotPasswordAction', [$request->toTransporter()]);
 
         return $this->noContent(202);
     }

--- a/app/Containers/Welcome/UI/CLI/Commands/SayWelcomeCommand.php
+++ b/app/Containers/Welcome/UI/CLI/Commands/SayWelcomeCommand.php
@@ -28,8 +28,6 @@ class SayWelcomeCommand extends ConsoleCommand
 
     /**
      * Create a new command instance.
-     *
-     * @return void
      */
     public function __construct()
     {

--- a/app/Containers/Wepay/Actions/CreateWepayAccountAction.php
+++ b/app/Containers/Wepay/Actions/CreateWepayAccountAction.php
@@ -6,7 +6,7 @@ use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\Wepay\Data\Repositories\WepayAccountRepository;
 use App\Containers\Wepay\Models\WepayAccount;
 use App\Ship\Parents\Actions\Action;
-use App\Ship\Transporters\DataTransporter;
+use App\Ship\Parents\Transporters\Transporter;
 use Illuminate\Support\Facades\App;
 
 /**
@@ -18,11 +18,11 @@ class CreateWepayAccountAction extends Action
 {
 
     /**
-     * @param \App\Ship\Transporters\DataTransporter $data
+     * @param \App\Ship\Parents\Transporters\Transporter $data
      *
      * @return  \App\Containers\Wepay\Models\WepayAccount
      */
-    public function run(DataTransporter $data): WepayAccount
+    public function run(Transporter $data): WepayAccount
     {
         $user = Apiato::call('Authentication@GetAuthenticatedUserTask');
 

--- a/app/Containers/Wepay/UI/API/Controllers/Controller.php
+++ b/app/Containers/Wepay/UI/API/Controllers/Controller.php
@@ -22,7 +22,7 @@ class Controller extends ApiController
      */
     public function createWepayAccount(CreateWepayAccountRequest $request)
     {
-        $wepayAccount = Apiato::call('Wepay@CreateWepayAccountAction', [new DataTransporter($request)]);
+        $wepayAccount = Apiato::call('Wepay@CreateWepayAccountAction', [$request->toTransporter()]);
 
         return $this->accepted([
             'message'        => 'Wepay account created successfully.',

--- a/app/Containers/Wepay/UI/API/Controllers/Controller.php
+++ b/app/Containers/Wepay/UI/API/Controllers/Controller.php
@@ -5,7 +5,6 @@ namespace App\Containers\Wepay\UI\API\Controllers;
 use Apiato\Core\Foundation\Facades\Apiato;
 use App\Containers\Wepay\UI\API\Requests\CreateWepayAccountRequest;
 use App\Ship\Parents\Controllers\ApiController;
-use App\Ship\Transporters\DataTransporter;
 
 /**
  * Class Controller.


### PR DESCRIPTION
This PR does the following thing:
1) it uses `run(Transporter...)` instead of `run(DataTransporter ...)` in the `Action` classes in order to make it more "maintainable"
2) it uses the new `$request->toTransporter()` method in the `Controller` instead of calling `new DataTransporter($request)`.

This PR requires also to merge the PR here ( https://github.com/apiato/core/pull/63 ) as this PR provides the `toTransporter()` function

I think, this PR makes the Transporter approach much more accessible for others and easier to maintain.