### PR TITLE
Added new Criteria - ThisLikeThat & ColumnBetweenDates

### DIFF
--- a/app/Ship/Criterias/Eloquent/ColumnBetweenDatesCriteria.php
+++ b/app/Ship/Criterias/Eloquent/ColumnBetweenDatesCriteria.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Ship\Criterias\Eloquent;
+
+use App\Ship\Parents\Criterias\Criteria;
+use Carbon\Carbon;
+use Illuminate\Database\Query\Builder;
+
+/**
+ * Class ColumnBetweenDatesCriteria
+ * @package App\Containers\WeatherData\Data\Criterias
+ * @author Fabian Widmann <fabian.widmann@gmail.com>
+ *
+ * Retrieves all entities whose date $field's value is between $from and $to.
+ */
+class ColumnBetweenDatesCriteria extends Criteria
+{
+
+    /**
+     * @var Carbon
+     */
+    private $from;
+
+    /**
+     * @var Carbon
+     */
+    private $to;
+
+    /**
+     * @var string
+     */
+    private $field;
+
+
+    public function __construct($field, Carbon $from, Carbon $to)
+    {
+        $this->from = $from;
+        $this->to = $to;
+        $this->field = $field;
+    }
+
+    /**
+     * Applies the criteria
+     * @param Builder $model
+     * @param  $repository
+     * @return  mixed
+     */
+    public function apply($model, $repository)
+    {
+        return $model->whereBetween($this->field, [$this->from->toDateString(), $this->to->toDateString()]);
+    }
+
+}

--- a/app/Ship/Criterias/Eloquent/ThisBetweenDatesCriteria.php
+++ b/app/Ship/Criterias/Eloquent/ThisBetweenDatesCriteria.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Query\Builder;
 
 /**
  * Class ThisBetweenDatesCriteria
- * @package App\Containers\WeatherData\Data\Criterias
+ * 
  * @author Fabian Widmann <fabian.widmann@gmail.com>
  *
  * Retrieves all entities whose date $field's value is between $start and $end.
@@ -41,13 +41,14 @@ class ThisBetweenDatesCriteria extends Criteria
 
     /**
      * Applies the criteria
+     * 
      * @param Builder $model
-     * @param  $repository
-     * @return  mixed
+     * @param         $repository
+     * 
+     * @return        mixed
      */
     public function apply($model, $repository)
     {
         return $model->whereBetween($this->field, [$this->start->toDateString(), $this->end->toDateString()]);
     }
-
 }

--- a/app/Ship/Criterias/Eloquent/ThisBetweenDatesCriteria.php
+++ b/app/Ship/Criterias/Eloquent/ThisBetweenDatesCriteria.php
@@ -7,24 +7,24 @@ use Carbon\Carbon;
 use Illuminate\Database\Query\Builder;
 
 /**
- * Class ColumnBetweenDatesCriteria
+ * Class ThisBetweenDatesCriteria
  * @package App\Containers\WeatherData\Data\Criterias
  * @author Fabian Widmann <fabian.widmann@gmail.com>
  *
- * Retrieves all entities whose date $field's value is between $from and $to.
+ * Retrieves all entities whose date $field's value is between $start and $end.
  */
-class ColumnBetweenDatesCriteria extends Criteria
+class ThisBetweenDatesCriteria extends Criteria
 {
 
     /**
      * @var Carbon
      */
-    private $from;
+    private $start;
 
     /**
      * @var Carbon
      */
-    private $to;
+    private $end;
 
     /**
      * @var string
@@ -32,10 +32,10 @@ class ColumnBetweenDatesCriteria extends Criteria
     private $field;
 
 
-    public function __construct($field, Carbon $from, Carbon $to)
+    public function __construct($field, Carbon $start, Carbon $end)
     {
-        $this->from = $from;
-        $this->to = $to;
+        $this->start = $start;
+        $this->end = $end;
         $this->field = $field;
     }
 
@@ -47,7 +47,7 @@ class ColumnBetweenDatesCriteria extends Criteria
      */
     public function apply($model, $repository)
     {
-        return $model->whereBetween($this->field, [$this->from->toDateString(), $this->to->toDateString()]);
+        return $model->whereBetween($this->field, [$this->start->toDateString(), $this->end->toDateString()]);
     }
 
 }

--- a/app/Ship/Criterias/Eloquent/ThisLikeThatCriteria.php
+++ b/app/Ship/Criterias/Eloquent/ThisLikeThatCriteria.php
@@ -8,7 +8,7 @@ use Prettus\Repository\Contracts\RepositoryInterface as PrettusRepositoryInterfa
 
 /**
  * Class ThisLikeThatCriteria
- * @package App\Ship\Criterias\Eloquent
+ * 
  * @author Fabian Widmann <fabian.widmann@gmail.com>
  *
  * Retrieves all entities where $field contains one or more of the given items in $valueString.
@@ -17,22 +17,22 @@ class ThisLikeThatCriteria extends Criteria
 {
 
     /**
-     * @var string - name of the column
+     * @var string name of the column
      */
     private $field;
 
     /**
-     * @var string - contains values separated by $separator
+     * @var string contains values separated by $separator
      */
     private $valueString;
 
     /**
-     * @var string - separates separate items in the given $values string. Default is csv.
+     * @var string separates separate items in the given $values string. Default is csv.
      */
     private $separator;
 
     /**
-     * @var string - this character is replaced with '%'. Default is *.
+     * @var string this character is replaced with '%'. Default is *.
      */
     private $wildcard;
 
@@ -47,8 +47,10 @@ class ThisLikeThatCriteria extends Criteria
 
     /**
      * Applies the criteria - if more than one value is separated by the configured separator we will "OR" all the params.
+     * 
      * @param  $model
      * @param  $repository
+     * 
      * @return  mixed
      */
     public function apply($model, $repository)

--- a/app/Ship/Criterias/Eloquent/ThisLikeThatCriteria.php
+++ b/app/Ship/Criterias/Eloquent/ThisLikeThatCriteria.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Ship\Criterias\Eloquent;
+
+use App\Ship\Parents\Criterias\Criteria;
+use Illuminate\Database\Query\Builder;
+use Prettus\Repository\Contracts\RepositoryInterface as PrettusRepositoryInterface;
+
+/**
+ * Class ThisLikeThatCriteria
+ * @package App\Ship\Criterias\Eloquent
+ * @author Fabian Widmann <fabian.widmann@gmail.com>
+ *
+ * Retrieves all entities where $field contains one or more of the given items in $valueString.
+ */
+class ThisLikeThatCriteria extends Criteria
+{
+
+    /**
+     * @var string - name of the column
+     */
+    private $field;
+
+    /**
+     * @var string - contains values separated by $separator
+     */
+    private $valueString;
+
+    /**
+     * @var string - separates separate items in the given $values string. Default is csv.
+     */
+    private $separator;
+
+    /**
+     * @var string - this character is replaced with '%'. Default is *.
+     */
+    private $wildcard;
+
+
+    public function __construct($field, $valueString, $separator = ',', $wildcard = '*')
+    {
+        $this->field = $field;
+        $this->valueString = $valueString;
+        $this->separator =$separator;
+        $this->wildcard =$wildcard;
+    }
+
+    /**
+     * Applies the criteria - if more than one value is separated by the configured separator we will "OR" all the params.
+     * @param  $model
+     * @param  $repository
+     * @return  mixed
+     */
+    public function apply($model, $repository)
+    {
+        $values = explode(config($this->separator), $this->valueString);
+        $model = $model->where($this->field, 'LIKE', str_replace($this->wildcard, '%', array_shift($values)));
+        foreach ($values as $value)
+            $model = $model->orWhere($this->field, 'LIKE', str_replace($this->wildcard, '%', $value));
+        return $model;
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Provided two new criteria that can be applied to several projects.
- _ThisBetweenDatesCriteria_: allows users to retrieve columns from a table whose `$field` is between `$start` and `$end` //name changed in second commit!
- _ThisLikeThatCriteria_: allows users to retrieve columns from a table where `$field` is like the given items in `$valueString`. Item separator and wildcard symbols can be changed by the user.
## Motivation and Context
<!--- Why is this change required? What problem does it solve, or what feature does it add? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Both criteria are general purpose and can be re-used for other projects

## How Has This Been Tested?
<!--- Please describe how you tested your changes. (PHPUnit is the highly recommended way) -->
Currently only manual testing has been done by creating a demoroute and testing both criteria with mock-data in a database. PHPUnit can be done if necessary.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We'd love to help! -->
- [?] My code follows the code style and structure of this project.
- [] I have updated the documentation accordingly.
