### PR TITLE
Localization needs php intl module

### DIFF
--- a/app/Containers/Localization/composer.json
+++ b/app/Containers/Localization/composer.json
@@ -3,6 +3,6 @@
   "description": "apiato Container.",
   "type": "apiato-container",
   "require": {
-
+    "ext-intl": "*"
   }
 }


### PR DESCRIPTION
 - see http://php.net/manual/en/book.intl.php
 - without this module, container throws Fatal: `Class 'Locale' not found`