### PR TITLE
Fixed the "ThisLikeThat" Criteria to now correctly be enclosed in par…

### DIFF
--- a/app/Ship/Criterias/Eloquent/ThisLikeThatCriteria.php
+++ b/app/Ship/Criterias/Eloquent/ThisLikeThatCriteria.php
@@ -3,6 +3,8 @@
 namespace App\Ship\Criterias\Eloquent;
 
 use App\Ship\Parents\Criterias\Criteria;
+use Prettus\Repository\Contracts\RepositoryInterface as PrettusRepositoryInterface;
+use Illuminate\Database\Query\Builder;
 
 /**
  * Class ThisLikeThatCriteria
@@ -46,12 +48,12 @@ class ThisLikeThatCriteria extends Criteria
     /**
      * Applies the criteria - if more than one value is separated by the configured separator we will "OR" all the params.
      *
-     * @param  $model
-     * @param  $repository
+     * @param  Builder $model
+     * @param \Prettus\Repository\Contracts\RepositoryInterface $repository
      *
      * @return  mixed
      */
-    public function apply($model, $repository)
+    public function apply($model, PrettusRepositoryInterface $repository)
     {
         return $model->where(function ($query) {
             $values = explode($this->separator, $this->valueString);

--- a/app/Ship/Criterias/Eloquent/ThisLikeThatCriteria.php
+++ b/app/Ship/Criterias/Eloquent/ThisLikeThatCriteria.php
@@ -3,12 +3,10 @@
 namespace App\Ship\Criterias\Eloquent;
 
 use App\Ship\Parents\Criterias\Criteria;
-use Illuminate\Database\Query\Builder;
-use Prettus\Repository\Contracts\RepositoryInterface as PrettusRepositoryInterface;
 
 /**
  * Class ThisLikeThatCriteria
- * 
+ *
  * @author Fabian Widmann <fabian.widmann@gmail.com>
  *
  * Retrieves all entities where $field contains one or more of the given items in $valueString.
@@ -41,25 +39,26 @@ class ThisLikeThatCriteria extends Criteria
     {
         $this->field = $field;
         $this->valueString = $valueString;
-        $this->separator =$separator;
-        $this->wildcard =$wildcard;
+        $this->separator = $separator;
+        $this->wildcard = $wildcard;
     }
 
     /**
      * Applies the criteria - if more than one value is separated by the configured separator we will "OR" all the params.
-     * 
+     *
      * @param  $model
      * @param  $repository
-     * 
+     *
      * @return  mixed
      */
     public function apply($model, $repository)
     {
-        $values = explode(config($this->separator), $this->valueString);
-        $model = $model->where($this->field, 'LIKE', str_replace($this->wildcard, '%', array_shift($values)));
-        foreach ($values as $value)
-            $model = $model->orWhere($this->field, 'LIKE', str_replace($this->wildcard, '%', $value));
-        return $model;
+        return $model->where(function ($query) {
+            $values = explode($this->separator, $this->valueString);
+            $query->where($this->field, 'LIKE', str_replace($this->wildcard, '%', array_shift($values)));
+            foreach ($values as $value)
+                $query->orWhere($this->field, 'LIKE', str_replace($this->wildcard, '%', $value));
+        });
     }
 
 }


### PR DESCRIPTION
…antheses.

Example:
Find all data whose type is like temperature or wind, where the source is equal to X:

select * from `weather_data` where (`type` LIKE %temperature% or `type` LIKE %wind%) and `source` = X"

Without the parantheses this would have been evaluted wrongly and would lead to also display temperature objects that do not have the source listed as X.


## Description
Enclosed the `where` and `orWhere` in a closure to add parantheses.

## How Has This Been Tested?
<!--- Please describe how you tested your changes. (PHPUnit is the highly recommended way) -->
Manual testing for one specific use case:
```php
$this->rep->pushCriteria(new LikeCriteria("type","a,b"));
$this->rep->pushCriteria(new ThisEqualThatCriteria("source","x"));
```
led to `SELECT * FROM table WHERE source="x" and type="b" or type="c"`
whereas the correct statement is: `SELECT * FROM table WHERE source="x" and (type="b" or type="c")` which is now created as it should have been.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)