### PR TITLE
remove codesponsor.io link

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -67,10 +67,6 @@ Your logo will show up on the [github repository](https://github.com/apiato/apia
 <a href="https://opencollective.com/apiato/sponsor/8/website" target="_blank"><img src="https://opencollective.com/apiato/sponsor/8/avatar.svg"></a>
 <a href="https://opencollective.com/apiato/sponsor/9/website" target="_blank"><img src="https://opencollective.com/apiato/sponsor/9/avatar.svg"></a>
 
-<a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/JHiroABWV9N5QKgcFuTA2NxX/apiato/apiato'>
-  <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/JHiroABWV9N5QKgcFuTA2NxX/apiato/apiato.svg' />
-</a>
-
 <a name="Documentation"></a>
 ## Documentation
 


### PR DESCRIPTION
Remove `codesponsor.io` link because it is shutting down

See this link for more information:
https://codesponsor.io/shutdown-notice/

See this other PR here
https://github.com/apiato/apiato/pull/360
that was closed because it would have actually deleted more details from the `README` file