### PR TITLE
Login with Custom Fields

### DIFF
--- a/app/Containers/Authentication/Actions/ProxyApiLoginAction.php
+++ b/app/Containers/Authentication/Actions/ProxyApiLoginAction.php
@@ -23,16 +23,40 @@ class ProxyApiLoginAction extends Action
             'grant_type'    => $data->grant_type ?? 'password',
             'client_id'     => $data->client_id,
             'client_secret' => $data->client_password,
-            'username'      => $data->email,
+            // 'username'      => $data->email,
             'password'      => $data->password,
             'scope'         => $data->scope ?? '',
         ];
+
+        $prefix = config('authentication-container.login.prefix', '');
+        $allowedLoginFields = config('authentication-container.login.allowed_login_attributes', ['email' => []]);
+        $fields = array_keys($allowedLoginFields);
+
+        $loginUsername = null;
+        $loginAttribute = null;
+
+        foreach ($fields as $field)
+        {
+            $fieldname = $prefix . $field;
+            $loginUsername = $data->getInputByKey($fieldname);
+            $loginAttribute = $field;
+
+            if ($loginUsername !== null) {
+                break;
+            }
+        }
+
+        $requestData = array_merge($requestData,
+            [
+                'username' => $loginUsername,
+            ]
+        );
 
         $responseContent = Apiato::call('Authentication@CallOAuthServerTask', [$requestData]);
 
         // check if user email is confirmed only if that feature is enabled.
         Apiato::call('Authentication@CheckIfUserIsConfirmedTask', [],
-            [['loginWithCredentials' => [$requestData['username'], $requestData['password']]]]);
+            [['loginWithCredentials' => [$requestData['username'], $requestData['password'], $loginAttribute]]]);
 
         $refreshCookie = Apiato::call('Authentication@MakeRefreshCookieTask', [$responseContent['refresh_token']]);
 

--- a/app/Containers/Authentication/Configs/authentication-container.php
+++ b/app/Containers/Authentication/Configs/authentication-container.php
@@ -40,4 +40,40 @@ return [
         // add your other clients here
     ],
 
+
+    'login' => [
+        /*
+        |--------------------------------------------------------------------------
+        | Prefix
+        |--------------------------------------------------------------------------
+        |
+        | Use this $prefix variable in order to allow for nested elements.
+        | For example, if your login fields are nested in "data.attributes.name / data.attributes.email"
+        | simply est the $prefix to "data.attributes." and you are good go to!
+        |
+        | Default: ''
+        |
+        */
+        'prefix' => '',
+
+        /*
+        |--------------------------------------------------------------------------
+        | Allowed Login Attributes
+        |--------------------------------------------------------------------------
+        |
+        | A list of fields the user is allowed to login with.
+        | Thereby, the key is the fieldname, the value (array) contains additional validation parameters that are applied!
+        |
+        | The order determines the order the fields are tested to login (in case multiple fields are submitted!
+        |
+        | Default: ['email' => ['email']
+        |
+        */
+        'allowed_login_attributes' => [
+            'email' => ['email'],
+            // 'name' => [],
+            // 'phone' => ['string', 'min:6', 'max:25'],
+        ],
+    ],
+
 ];

--- a/app/Containers/Authentication/Data/Transporters/ProxyApiLoginTransporter.php
+++ b/app/Containers/Authentication/Data/Transporters/ProxyApiLoginTransporter.php
@@ -19,6 +19,9 @@ class ProxyApiLoginTransporter extends Transporter
         'type' => 'object',
         'properties' => [
             'email',
+            // 'name',
+            // 'phone',
+
             'password',
             'client_id',
             'client_password',
@@ -26,7 +29,6 @@ class ProxyApiLoginTransporter extends Transporter
             'scope',
         ],
         'required'   => [
-            'email',
             'password',
             'client_id',
             'client_password',

--- a/app/Containers/Authentication/Tasks/CheckIfUserIsConfirmedTask.php
+++ b/app/Containers/Authentication/Tasks/CheckIfUserIsConfirmedTask.php
@@ -16,21 +16,28 @@ class CheckIfUserIsConfirmedTask extends Task
     public function run()
     {
         // is the config flag set?
-        if(Config::get('authentication-container.require_email_confirmation')) {
+        if (Config::get('authentication-container.require_email_confirmation', false)) {
 
-            if(! $this->user) {
+            if (! $this->user) {
                 throw new LoginFailedException();
             }
 
-            if(! $this->user->confirmed) {
+            if (! $this->user->confirmed) {
                 throw new UserNotConfirmedException();
             }
         }
     }
 
-    public function loginWithCredentials($email, $password)
+    /**
+     * @param string $username The username / email / whatever to be used
+     * @param string $password the corresponding password
+     * @param string $field the field to be checked against
+     *
+     * @throws LoginFailedException
+     */
+    public function loginWithCredentials($username, $password, $field = 'email')
     {
-        if(Auth::attempt(['email' => $email, 'password' => $password])) {
+        if (Auth::attempt([$field => $username, 'password' => $password])) {
             $this->user = Auth::user();
         }
         else {

--- a/app/Containers/Authentication/UI/API/Tests/Functional/ProxyLoginTest.php
+++ b/app/Containers/Authentication/UI/API/Tests/Functional/ProxyLoginTest.php
@@ -88,6 +88,137 @@ class ProxyLoginTest extends ApiTestCase
     /**
      * @test
      */
+    public function testLoginWithNameAttribute_()
+    {
+        $endpoint = 'post@v1/clients/web/admin/login';
+
+        // create data to be used for creating the testing user and to be sent with the post request
+        $data = [
+            'email'    => 'testing@mail.com',
+            'password' => 'testingpass',
+            'name'     => 'username',
+        ];
+
+        $user = $this->getTestingUser($data);
+        $this->actingAs($user, 'web');
+
+        $clientId = '100';
+        $clientSecret = 'XXp8x4QK7d3J9R7OVRXWrhc19XPRroHTTKIbY8XX';
+
+        // create client
+        DB::table('oauth_clients')->insert([
+            [
+                'id'                     => $clientId,
+                'secret'                 => $clientSecret,
+                'name'                   => 'Testing',
+                'redirect'               => 'http://localhost',
+                'password_client'        => '1',
+                'personal_access_client' => '0',
+                'revoked'                => '0',
+            ],
+        ]);
+
+        // make the clients credentials available as env variables
+        Config::set('authentication-container.clients.web.admin.id', $clientId);
+        Config::set('authentication-container.clients.web.admin.secret', $clientSecret);
+
+        // specifically allow to login with "name" attribute
+        Config::set('authentication-container.login.allowed_login_attributes',
+            [
+                'email' => ['email'],
+                'name' => [],
+            ]
+        );
+
+        // create testing oauth keys files
+        $publicFilePath = $this->createTestingKey('oauth-public.key');
+        $privateFilePath = $this->createTestingKey('oauth-private.key');
+
+        $request = [
+            'password' => 'testingpass',
+            'name'     => 'username',
+        ];
+
+        $response = $this->endpoint($endpoint)->makeCall($request);
+
+        $response->assertStatus(200);
+
+        $response->assertCookie('refreshToken');
+
+        $this->assertResponseContainKeyValue([
+            'token_type' => 'Bearer',
+        ]);
+
+        $this->assertResponseContainKeys(['expires_in', 'access_token']);
+
+        // delete testing keys files if they were created for this test
+        if ($this->testingFilesCreated) {
+            unlink($publicFilePath);
+            unlink($privateFilePath);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function testLoginWithDeviceAttribute_()
+    {
+        $endpoint = 'post@v1/clients/web/admin/login';
+
+        // create data to be used for creating the testing user and to be sent with the post request
+        $data = [
+            'email'    => 'testing@mail.com',
+            'password' => 'testingpass',
+            'name'     => 'username',
+        ];
+
+        $user = $this->getTestingUser($data);
+        $this->actingAs($user, 'web');
+
+        $clientId = '100';
+        $clientSecret = 'XXp8x4QK7d3J9R7OVRXWrhc19XPRroHTTKIbY8XX';
+
+        // create client
+        DB::table('oauth_clients')->insert([
+            [
+                'id'                     => $clientId,
+                'secret'                 => $clientSecret,
+                'name'                   => 'Testing',
+                'redirect'               => 'http://localhost',
+                'password_client'        => '1',
+                'personal_access_client' => '0',
+                'revoked'                => '0',
+            ],
+        ]);
+
+        // make the clients credentials available as env variables
+        Config::set('authentication-container.clients.web.admin.id', $clientId);
+        Config::set('authentication-container.clients.web.admin.secret', $clientSecret);
+
+        // create testing oauth keys files
+        $publicFilePath = $this->createTestingKey('oauth-public.key');
+        $privateFilePath = $this->createTestingKey('oauth-private.key');
+
+        $request = [
+            'password' => 'testingpass',
+            'device'   => 'My Fancy Device',
+        ];
+
+        $response = $this->endpoint($endpoint)->makeCall($request);
+
+        // we test for HTTP 400 because the user is not allowed to login via name attribute
+        $response->assertStatus(400);
+
+        // delete testing keys files if they were created for this test
+        if ($this->testingFilesCreated) {
+            unlink($publicFilePath);
+            unlink($privateFilePath);
+        }
+    }
+
+    /**
+     * @test
+     */
     public function testClientWebAdminProxyUnconfirmedLogin_()
     {
         $endpoint = 'post@v1/clients/web/admin/login';

--- a/app/Ship/Parents/Models/UserModel.php
+++ b/app/Ship/Parents/Models/UserModel.php
@@ -25,4 +25,21 @@ abstract class UserModel extends AbstractUserModel
     use HasApiTokens;
     use HasResourceKeyTrait;
 
+    public function findForPassport($identifier)
+    {
+        $allowedLoginAttributes = config('authentication-container.login.allowed_login_attributes', ['email' => []]);
+        $fields = array_keys($allowedLoginAttributes);
+
+        $builder = $this;
+
+        foreach ($fields as $field)
+        {
+            $builder = $builder->orWhere($field, $identifier);
+        }
+
+        $builder = $builder->first();
+
+        return $builder;
+    }
+
 }


### PR DESCRIPTION
This PR allows users to log in with different attributes than `email`.
The feature is customizable and easy to extend.

http://docs.apiato.io/features/authentication/#login-with-custom-attributes