### PR TITLE
Don't publish these files and folders

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
 * text=auto
 *.css linguist-vendored
 *.scss linguist-vendored
+.github export-ignore
+CHANGELOG.md export-ignore
+.scrutinizer.yml export-ignore
+.travis.yml export-ignore
+.env.travis export-ignore


### PR DESCRIPTION
Hi,

## Description
We can instruct Github not include these files when creating the release zip archive.
Since composer downloads the [zip](https://github.com/apiato/apiato/archive/v7.4.7.zip) from Github, it wont include these files when someone run `composer create-project` command.
You may also want to exclude `LICENSE` file, like laravel/laravel do

## Motivation and Context
* You don't want your `.github` folder in our projects.
* We always delete these unwanted files and folders.
* Each project may have its own `CHANGELOG.md` , CI server configs and so on.

## How Has This Been Tested?
[Laravel/Laravel](https://github.com/laravel/laravel/blob/master/.gitattributes) and 
[Laravel/framework](https://github.com/laravel/framework/blob/5.6/.gitattributes) is already doing that and may be many others.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We'd love to help! -->
- [x] My code follows the code style and structure of this project.
- [x] I have updated the documentation accordingly.
