### PR TITLE
Change UnsupportedLanguageException to return fallback locale

### DIFF
--- a/app/Containers/Localization/Middlewares/LocalizationMiddleware.php
+++ b/app/Containers/Localization/Middlewares/LocalizationMiddleware.php
@@ -87,8 +87,8 @@ class LocalizationMiddleware extends Middleware
             }
         }
 
-        // we have not found any language that is supported
-        throw new UnsupportedLanguageException();
+        // return fallback locale if we have not found any language that is supported
+        return Config::get('app.fallback_locale');
     }
 
     /**

--- a/app/Containers/Localization/UI/API/Tests/Functional/CheckLocalizationMiddlewareTest.php
+++ b/app/Containers/Localization/UI/API/Tests/Functional/CheckLocalizationMiddlewareTest.php
@@ -62,7 +62,7 @@ class CheckLocalizationMiddlewareTest extends ApiTestCase
         $response->assertHeader('content-language', $language);
     }
 
-    public function test_if_middleware_throws_error_on_wrong_language()
+    public function test_if_middleware_sets_fallback_app_language_instead_wrong_language()
     {
         $language = 'xxx';
 
@@ -75,7 +75,11 @@ class CheckLocalizationMiddlewareTest extends ApiTestCase
         $response = $this->makeCall($data, $requestHeaders);
 
         // assert the response status
-        $response->assertStatus(412);
-    }
+        $response->assertStatus(200);
 
+        $fallbackLanguage = Config::get('app.fallback_locale');
+
+        // check if the header is properly set
+        $response->assertHeader('content-language', $fallbackLanguage);
+    }
 }


### PR DESCRIPTION
## Description
in `LocalizationMiddleware.php` I'm chacnge throw `UnsupportedLanguageException` to return `app.fallback_locale`.

## Motivation and Context
Now if the user request has a non-supported locale in Accept-Language header, it will receive an Exception.
At least for web requests - it looks wrong. In such cases, users can't control the contents of their headers.
I suggest returning fallback locale value instead of an error in such cases.
Especially since laravel has this parameter out of the box.

If you think that an exception is also necessary - maybe we can manage this from the configuration, or split the scripts for api and web requests? 

## How Has This Been Tested?
Middleware test was also changed.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style and structure of this project.
- [ ] I have updated the documentation accordingly.
