### PR TITLE
Throw not found exception in findUser tasks (#456).

### DIFF
--- a/app/Containers/User/Tasks/FindUserByEmailTask.php
+++ b/app/Containers/User/Tasks/FindUserByEmailTask.php
@@ -16,6 +16,9 @@ use Exception;
 class FindUserByEmailTask extends Task
 {
 
+    /**
+     * @var UserRepository
+     */
     protected $repository;
 
     public function __construct(UserRepository $repository)
@@ -31,10 +34,11 @@ class FindUserByEmailTask extends Task
      */
     public function run(string $email): User
     {
-        try {
-            return $this->repository->findByField('email', $email)->first();
-        } catch (Exception $e) {
+        $user = $this->repository->findByField('email', $email)->first();
+        if (null === $user) {
             throw new NotFoundException();
         }
+
+        return $user;
     }
 }


### PR DESCRIPTION
FindUserByEmailTask is not throwing the exception when a user is not found instead the tasks returns null and a error 500 is returned.

## Description
Throw NotFoundException when findByField returns null

## Motivation and Context
If the email doesn't exists an error 500 is returned.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style and structure of this project.
- [] I have updated the documentation accordingly.
