### PR TITLE
Use the API prefix even on Passport oauth routes

### DIFF
--- a/app/Containers/Authentication/Providers/AuthProvider.php
+++ b/app/Containers/Authentication/Providers/AuthProvider.php
@@ -56,7 +56,7 @@ class AuthProvider extends ParentAuthProvider
      */
     private function registerPassport()
     {
-        $routeGroupArray = $this->getRouteGroup('/v1');
+        $routeGroupArray = $this->getRouteGroup(Config::get('apiato.api.prefix') . 'v1');
 
         Route::group($routeGroupArray, function () {
             Passport::routes();


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I was looking around, confirming the API prefix functionality when I came across AuthenticationProvider not using the prefix in oauth routes.

## Motivation and Context
This is because it's confusing to have these auth routes remain on `http://example.com/v1/...` when the rest is `http://example.com/{prefix}/v1/...`.


## How Has This Been Tested?
<!--- Please describe how you tested your changes. (PHPUnit is the highly recommended way) -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We'd love to help! -->
- [] My code follows the code style and structure of this project.
- [] I have updated the documentation accordingly.
