### PR TITLE
Update .dev to .develop in example .env. Once renamed by developers should provide a better default.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,8 @@ APP_LOG_LEVEL=debug
 LOG_CHANNEL=stack
 
 APP_NAME="apiato"
-APP_URL=http://apiato.dev
-API_URL=http://api.apiato.dev
+APP_URL=http://apiato.develop
+API_URL=http://api.apiato.develop
 
 API_PREFIX=/
 


### PR DESCRIPTION

## Description
Change from default domain extension of .dev to .develop

## Motivation and Context
Moved away from .dev due to ICANN, updated example to prevent end users from missing this.

## How Has This Been Tested?
Spent last half hour trying to get requests in POSTMAN to resolve without this change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We'd love to help! -->
- [X] My code follows the code style and structure of this project.
- [X] I have updated the documentation accordingly.
