### PR TITLE
Add CORS and Hashids config files for Laravel 7 compatibility

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cross-Origin Resource Sharing (CORS) Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your settings for cross-origin resource sharing
+    | or "CORS". This determines what cross-origin operations may execute
+    | in web browsers. You are free to adjust these settings as needed.
+    |
+    | To learn more: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+    |
+    */
+
+    'paths' => ['api/*'],
+
+    'allowed_methods' => ['*'],
+
+    'allowed_origins' => ['*'],
+
+    'allowed_origins_patterns' => [],
+
+    'allowed_headers' => ['*'],
+
+    'exposed_headers' => [],
+
+    'max_age' => 0,
+
+    'supports_credentials' => false,
+
+];

--- a/config/cors.php
+++ b/config/cors.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'paths' => ['api/*'],
+    'paths' => ['v1/*'],
 
     'allowed_methods' => ['*'],
 

--- a/config/hashids.php
+++ b/config/hashids.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of Laravel Hashids.
+ *
+ * (c) Vincent Klaiber <hello@vinkla.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Connection Name
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify which of the connections below you wish to use as
+    | your default connection for all work. Of course, you may use many
+    | connections at once using the manager class.
+    |
+    */
+
+    'default' => 'main',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Hashids Connections
+    |--------------------------------------------------------------------------
+    |
+    | Here are each of the connections setup for your application. Example
+    | configuration has been included, but you may add as many connections as
+    | you would like.
+    |
+    */
+
+    'connections' => [
+
+        'main' => [
+            'salt'     => env('HASH_ID_KEY', env('APP_KEY')),
+            'length'   => env('HASH_ID_LENGTH', 32),
+            'alphabet' => '1234567890abcdefghijklmnopqrstuvwxyz',
+        ],
+
+        'alternative' => [
+            'salt'     => 'your-salt-string',
+            'length'   => 'your-length-integer',
+            'alphabet' => 'your-alphabet-string',
+        ],
+
+    ],
+
+];


### PR DESCRIPTION
<!--- If you are unsure which branch your pull request should be sent to, please read: http://docs.apiato.io/miscellaneous/contribution/#Git-Branches -->

## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Add `config/cors.php` from Laravel 7, since these settings are now required for API access.
- Change default CORS path to `v1/*` in order to comply with Apiato prefix.
- Add `config/hashids.php`, since the settings in Ship/core did not get applied anymore.

## Motivation and Context
<!--- What problem does it solve, or what feature does it add? -->
- API requests got blocked due to missing CORS configuration.
- Encoding and Decoding of Hashids did not use Apiato's settings.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style and structure of this project.
- [] I have updated the documentation accordingly.
