### PR TITLE
return builder with chained statements in AuthenticationTrait

### DIFF
--- a/app/Containers/Authorization/Traits/AuthenticationTrait.php
+++ b/app/Containers/Authorization/Traits/AuthenticationTrait.php
@@ -21,8 +21,10 @@ trait AuthenticationTrait
     {
         $allowedLoginAttributes = config('authentication-container.login.attributes', ['email' => []]);
 
-        foreach (array_keys($allowedLoginAttributes) as $field) {
-            $builder = $this->orWhere($field, $identifier);
+        $builder = $this;
+        foreach (array_keys($allowedLoginAttributes) as $field)
+        {
+            $builder = $builder->orWhere($field, $identifier);
         }
 
         return $builder->first();


### PR DESCRIPTION
<!--- If you are unsure which branch your pull request should be sent to, please read: http://docs.apiato.io/miscellaneous/contribution/#Git-Branches -->

## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->
Builder instance in AuthenticationTrait now chains multiple attributes (if defined) correctly.

## Motivation and Context
<!--- What problem does it solve, or what feature does it add? -->
If multiple attributes were defined in authentication-container config, Passport authentication did not work correctly, since AuthenticationTrait checked only one attribute.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style and structure of this project.
- [] I have updated the documentation accordingly.
