### PR TITLE
Make passport respect api prefix

### DIFF
--- a/app/Containers/Authentication/Providers/AuthProvider.php
+++ b/app/Containers/Authentication/Providers/AuthProvider.php
@@ -56,7 +56,7 @@ class AuthProvider extends ParentAuthProvider
      */
     private function registerPassport()
     {
-        $routeGroupArray = $this->getRouteGroup('/v1');
+        $routeGroupArray = $this->getRouteGroup('/'.Config::get('apiato.api.prefix').'v1');
 
         Route::group($routeGroupArray, function () {
             Passport::routes();


### PR DESCRIPTION
## Description
Give api prefix to path of passport.

## Motivation and Context
Url from laravel passport always /v1/oauth.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
If someone use old code with prefix must call /v1/oauth. With this fix, must call /prefix/v1/oauth

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style and structure of this project.
- [] I have updated the documentation accordingly.
