### PR TITLE
Fix order of loading config files from ship and vendors. Fixes #574...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-  - '7.2'
-  - '7.3'
   - '7.4'
 
 dist: trusty
@@ -17,8 +15,8 @@ before_install:
   - travis_retry composer self-update
 
 install:
-  - if [[ $setup = 'stable' ]]; then travis_retry composer update --prefer-dist --prefer-stable --no-interaction --no-suggest; fi
-  - if [[ $setup = 'normal' ]]; then travis_retry composer update --prefer-dist --no-interaction --prefer-stable --no-suggest; fi
+  - if [[ $setup = 'stable' ]]; then COMPOSER_MEMORY_LIMIT=-1 travis_retry composer update --prefer-dist --prefer-stable --no-interaction --no-suggest; fi
+  - if [[ $setup = 'normal' ]]; then COMPOSER_MEMORY_LIMIT=-1 travis_retry composer update --prefer-dist --no-interaction --prefer-stable --no-suggest; fi
 
 before_script:
   - cp .env.travis .env

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
   },
   "extra": {
     "laravel": {
-      "dont-discover": []
+      "dont-discover": ["*"]
     },
     "merge-plugin": {
       "include": [


### PR DESCRIPTION
## Description
I know it's a small change but it fixed a lot of issues. Without it, order of loading config files is messed up. First configs from vendors would load, and then from Ship, which results in most of the Ship configs not being applied. Example issue #574, but also hashids config not being applied.

## Motivation and Context
Fixed order of loading configs, so first ones from Ship would load and then vendors. (Ex. cors.php, hashids.php)

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [x] My code follows the code style and structure of this project.
- [] I have updated the documentation accordingly.
