### PR TITLE
Avoid using spread operator for the sake of php version

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Apiato
 
-<h3 align="center">Build scalable API's faster | With PHP 7.4 and Laravel 7</h3>
+<h3 align="center">Build scalable API's faster | With PHP 7.2.5 and Laravel 7.0</h3>
 
 <p align="center">
    <img src="https://github.com/apiato/documentation/blob/master/images/apiato-icon-medium.png" alt="Apiato Logo"/>

--- a/app/Containers/Documentation/Tasks/GenerateAPIDocsTask.php
+++ b/app/Containers/Documentation/Tasks/GenerateAPIDocsTask.php
@@ -29,17 +29,20 @@ class GenerateAPIDocsTask extends Task
     {
         $path = $this->getDocumentationPath($type);
 
-        $command = [
+        $command = array_merge(
+          [
             $this->getExecutable(),
-            // executable parameters
             "-c",
-            $this->getJsonFilePath($type),
-            ...$this->getEndpointFiles($type),
+            $this->getJsonFilePath($type)
+          ],
+          $this->getEndpointFiles($type),
+          [
             "-i",
             "app",
             "-o",
             $path
-        ];
+          ]
+        );
 
         $process = new Process($command);
 

--- a/app/Containers/Documentation/Traits/DocsGeneratorTrait.php
+++ b/app/Containers/Documentation/Traits/DocsGeneratorTrait.php
@@ -108,7 +108,7 @@ trait DocsGeneratorTrait
     /**
      * @param $type
      *
-     * @return  string
+     * @return  array
      */
     private function getEndpointFiles($type)
     {


### PR DESCRIPTION
## Description
After changing php version from `7.4` to `7.2.5` some parts of the code started not working, for example we used to use `spread operator` in 7.4 but after the change of php version we had to remove this operation and write the code in another way.

## Motivation and Context
An error was stopping us from generating apidoc

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [x] My code follows the code style and structure of this project.
- [] I have updated the documentation accordingly.
