### PR TITLE
Fix default transporter additional properties

### DIFF
--- a/app/Ship/Transporters/DataTransporter.php
+++ b/app/Ship/Transporters/DataTransporter.php
@@ -24,8 +24,9 @@ class DataTransporter extends Transporter
     protected $schema = [
         'type' => 'object',
         'properties' => [
-            'additionalProperties' => true,
+            //
         ],
+        'additionalProperties' => true,
         'required' => [  // defined Transporter required fields ['first_name', 'last_name'],
 
         ],


### PR DESCRIPTION
<!--- If you are unsure which branch your pull request should be sent to, please read: http://docs.apiato.io/miscellaneous/contribution/#Git-Branches -->

## Description
<!--- Describe your changes in detail -->
<!--- If it fixes an open issue, please link to the issue here. -->
As indicated in the DTO package documentation, additionalProperties key has to be defined in schema root array
https://github.com/fireproofsocks/dto/wiki/GettingStarted#refining-our-dto-schema

Related issue: #584

## Motivation and Context
<!--- What problem does it solve, or what feature does it add? -->
Fix default DataTransporter class additionalProperties.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style and structure of this project.
- [] I have updated the documentation accordingly.
