### PR TITLE
HashId Issue

### DIFF
--- a/app/Ship/core/Traits/HashIdTrait.php
+++ b/app/Ship/core/Traits/HashIdTrait.php
@@ -124,7 +124,7 @@ trait HashIdTrait
 
         } else {
             // check if the key we are looking for does, in fact, really exist
-            if (!array_key_exists($field, $data)) {
+            if (!is_array($data) || !array_key_exists($field, $data)) {
                 return $data;
             }
 


### PR DESCRIPTION
Fixes the bug with the error:
`"array_key_exists() expects parameter 2 to be array, null given"`

<!--- If you are unsure which branch your pull request should be sent to, please read: http://docs.apiato.io/miscellaneous/contribution/#Git-Branches -->

## Description
I think, I've found a bug within the Request.

When you pass NULL value to a decodable field it gives an error like this:
`"array_key_exists() expects parameter 2 to be array, null given"`


## Reproducing
It happened to me when I had a $decode property in my Request like this:
```
protected $decode = [
     'data.id'
  ];
```

Then I've sent a query request to it with a `NULL` id value. The result was an error like I mentioned above:
```
"array_key_exists() expects parameter 2 to be array, null given"
```

I hope the pull request will be confirmed. If you have another solution. Please let us know 😊

