### PR TITLE
Update .editorconfig file to match laravel style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,13 +4,13 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 2
-indent_style = space
 insert_final_newline = true
+indent_style = space
+indent_size = 4
 trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
 
-[*.py]
-indent_size = 4
+[*.{yml,yaml}]
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Alternatively, you can build it using the [MVC](http://docs.apiato.io/getting-st
 <p align="center">Join our Slack chatting room, by clicking on the icon below.</p>
 
 <p align="center">
-	<a href="https://apiato.slack.com/join/shared_invite/zt-k0iffdzo-96hCTlPUt77Eq6tbD~Ip7Q#">
+	<a href="https://join.slack.com/t/apiato/shared_invite/zt-kud76ww7-vU6UyJ1yf1okdK5DWPv0HQ">
 	   <img src="https://s19.postimg.cc/h7pvzy9ar/Slack-i_OS-icon.png" alt="Apiato SLACK"/>
 	</a>
 </p>

--- a/app/Containers/Authorization/Data/Migrations/2016_12_29_201047_create_permission_tables.php
+++ b/app/Containers/Authorization/Data/Migrations/2016_12_29_201047_create_permission_tables.php
@@ -16,7 +16,7 @@ class CreatePermissionTables extends Migration
         $foreignKeys = config('permission.foreign_keys');
 
         Schema::create($tableNames['permissions'], function (Blueprint $table) {
-            $table->increments('id');
+            $table->id('id');
             $table->string('name');
             $table->string('guard_name');
             $table->string('display_name')->nullable();
@@ -25,7 +25,7 @@ class CreatePermissionTables extends Migration
         });
 
         Schema::create($tableNames['roles'], function (Blueprint $table) {
-            $table->increments('id');
+            $table->id('id');
             $table->string('name');
             $table->string('guard_name');
             $table->string('display_name')->nullable();
@@ -34,42 +34,37 @@ class CreatePermissionTables extends Migration
         });
 
         Schema::create($tableNames['model_has_permissions'], function (Blueprint $table) use ($tableNames, $foreignKeys) {
-            $table->integer('permission_id')->unsigned();
             $table->morphs('model');
 
-            $table->foreign('permission_id')
+            $table->foreignId('permission_id')
                 ->references('id')
                 ->on($tableNames['permissions'])
-                ->onDelete('cascade');
+                ->cascadeOnDelete();
 
             $table->primary(['model_type', 'model_id', 'permission_id']);
         });
 
         Schema::create($tableNames['model_has_roles'], function (Blueprint $table) use ($tableNames, $foreignKeys) {
-            $table->integer('role_id')->unsigned();
             $table->morphs('model');
 
-            $table->foreign('role_id')
+            $table->foreignId('role_id')
                 ->references('id')
                 ->on($tableNames['roles'])
-                ->onDelete('cascade');
+                ->cascadeOnDelete();
 
             $table->primary(['model_id', 'role_id', 'model_type']);
         });
 
         Schema::create($tableNames['role_has_permissions'], function (Blueprint $table) use ($tableNames) {
-            $table->integer('permission_id')->unsigned();
-            $table->integer('role_id')->unsigned();
-
-            $table->foreign('permission_id')
+            $table->foreignId('permission_id')
                 ->references('id')
                 ->on($tableNames['permissions'])
-                ->onDelete('cascade');
+                ->cascadeOnDelete();
 
-            $table->foreign('role_id')
+            $table->foreignId('role_id')
                 ->references('id')
                 ->on($tableNames['roles'])
-                ->onDelete('cascade');
+                ->cascadeOnDelete();
 
             $table->primary(['role_id', 'permission_id']);
         });

--- a/app/Containers/Payment/Data/Migrations/2000_01_02_000001_create_payment_accounts_table.php
+++ b/app/Containers/Payment/Data/Migrations/2000_01_02_000001_create_payment_accounts_table.php
@@ -18,13 +18,12 @@ class CreatePaymentAccountsTable extends Migration
     {
         Schema::create('payment_accounts', function (Blueprint $table) {
 
-            $table->increments('id');
+            $table->id('id');
             $table->string('name')->nullable();
 
             $table->morphs('accountable');
 
-            $table->integer('user_id')->unsigned();
-            $table->foreign('user_id')->references('id')->on('users');
+            $table->foreignId('user_id')->constrained();
 
             $table->timestamps();
             $table->softDeletes();

--- a/app/Containers/Payment/Data/Migrations/2018_01_01_000001_create_payment_transactions_table.php
+++ b/app/Containers/Payment/Data/Migrations/2018_01_01_000001_create_payment_transactions_table.php
@@ -18,10 +18,9 @@ class CreatePaymentTransactionsTable extends Migration
     {
         Schema::create('payment_transactions', function (Blueprint $table) {
 
-            $table->increments('id');
+            $table->id('id');
 
-            $table->integer('user_id')->unsigned();
-            $table->foreign('user_id')->references('id')->on('users');
+            $table->foreignId('user_id')->constrained();
 
             $table->string('gateway');
             $table->string('transaction_id');

--- a/app/Containers/Settings/Data/Migrations/2016_20_09_030201_create_settings_table.php
+++ b/app/Containers/Settings/Data/Migrations/2016_20_09_030201_create_settings_table.php
@@ -12,7 +12,7 @@ class CreateSettingsTable extends Migration
     public function up()
     {
         Schema::create('settings', function (Blueprint $table) {
-            $table->increments('id');
+            $table->id('id');
             $table->string('key')->unique();
             $table->string('value');
         });

--- a/app/Containers/SocialAuth/Data/Migrations/2017_10_26_214459_update_user_table_with_socialauth_columns.php
+++ b/app/Containers/SocialAuth/Data/Migrations/2017_10_26_214459_update_user_table_with_socialauth_columns.php
@@ -30,15 +30,17 @@ class UpdateUserTableWithSocialauthColumns extends Migration
     public function down()
     {
         Schema::table('users', function (Blueprint $table) {
-//            $table->dropColumn('social_provider');
-//            $table->dropColumn('social_nickname');
-//            $table->dropColumn('social_id');
-//            $table->dropColumn('social_token');
-//            $table->dropColumn('social_token_secret');
-//            $table->dropColumn('social_refresh_token');
-//            $table->dropColumn('social_expires_in');
-//            $table->dropColumn('social_avatar');
-//            $table->dropColumn('social_avatar_original');
+            $table->dropColumn([
+                'social_provider',
+                'social_nickname',
+                'social_id',
+                'social_token',
+                'social_token_secret',
+                'social_refresh_token',
+                'social_expires_in',
+                'social_avatar',
+                'social_avatar_original',
+            ]);
         });
     }
 }

--- a/app/Containers/Stripe/Data/Migrations/2016_07_08_110947_create_stripe_accounts_table.php
+++ b/app/Containers/Stripe/Data/Migrations/2016_07_08_110947_create_stripe_accounts_table.php
@@ -19,7 +19,7 @@ class CreateStripeAccountsTable extends Migration
     public function up()
     {
         Schema::create('stripe_accounts', function (Blueprint $table) {
-            $table->increments('id');
+            $table->id('id');
 
             $table->string('customer_id');
             $table->string('card_id')->nullable();

--- a/app/Containers/User/Data/Migrations/2000_01_01_000001_create_users_table.php
+++ b/app/Containers/User/Data/Migrations/2000_01_01_000001_create_users_table.php
@@ -12,7 +12,7 @@ class CreateUsersTable extends Migration
     public function up()
     {
         Schema::create('users', function (Blueprint $table) {
-            $table->increments('id');
+            $table->id('id');
 
             $table->string('name')->nullable();
             $table->string('email')->unique()->nullable();

--- a/app/Ship/Migrations/2017_03_28_203558_create_jobs_table.php
+++ b/app/Ship/Migrations/2017_03_28_203558_create_jobs_table.php
@@ -22,7 +22,7 @@ class CreateJobsTable extends Migration
     {
         if(Config::get('queue.default') == 'database'){
             Schema::create('jobs', function (Blueprint $table) {
-                $table->bigIncrements('id');
+                $table->id('id');
                 $table->string('queue');
                 $table->longText('payload');
                 $table->tinyInteger('attempts')->unsigned();

--- a/app/Ship/Migrations/2017_03_28_203559_create_failed_jobs_table.php
+++ b/app/Ship/Migrations/2017_03_28_203559_create_failed_jobs_table.php
@@ -20,7 +20,7 @@ class CreateFailedJobsTable extends Migration
     public function up()
     {
         Schema::create('failed_jobs', function (Blueprint $table) {
-            $table->increments('id');
+            $table->id('id');
             $table->text('connection');
             $table->text('queue');
             $table->longText('payload');

--- a/app/Ship/core/Generator/Stubs/migration.stub
+++ b/app/Ship/core/Generator/Stubs/migration.stub
@@ -13,7 +13,7 @@ class {{class-name}} extends Migration
     {
         Schema::create('{{table-name}}', function (Blueprint $table) {
 
-            $table->increments('id');
+            $table->id('id');
 
             $table->timestamps();
             //$table->softDeletes();


### PR DESCRIPTION
## Description
I changed content of .editorconfig to match how laravel works, in this commit we have `indent_size` change from 2 to 4 and a line of code which keeps `indent_size` for `yaml` files still 2. This is exactly how a laravel developer expects.

## Motivation and Context
All the code in apiato and laravel is written with `indent_size = 2` and when the developer tries to `rearrange` or `reformat` the code every line gets some changes, in this situation the developer is confused and prefers not to clean the code!!! But after this change everything will work properly.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [x] My code follows the code style and structure of this project.
- [] I have updated the documentation accordingly.
