### PR TITLE
model_locations in ide-helper.php

### DIFF
--- a/app/Ship/Configs/ide-helper.php
+++ b/app/Ship/Configs/ide-helper.php
@@ -128,7 +128,7 @@ return [
     */
 
     'model_locations' => [
-        'app/Containers/*/Models'
+        'app/Containers/*/*/Models'
     ],
 
     /*


### PR DESCRIPTION
Fix "model_locations" for correct work "php artisan ide-helper:model" with Sections and Containers

## Description
Change field "model_locations" in config for ide-helper


## Motivation and Context
In new version Apiato was added "Sections" for group Containers, and ide-helper can't generate because "model_locations" have wrong path to models

## Types of Changes
- Bug fix 

## Definition of Done Checklist:
- My code follows the code style and structure of this project.
- I have updated the documentation accordingly.
