### PR TITLE
Update user, role and permission repository model bindings to allow custom model binding

### DIFF
--- a/app/Containers/AppSection/Authorization/Data/Repositories/PermissionRepository.php
+++ b/app/Containers/AppSection/Authorization/Data/Repositories/PermissionRepository.php
@@ -2,7 +2,6 @@
 
 namespace App\Containers\AppSection\Authorization\Data\Repositories;
 
-use App\Containers\AppSection\Authorization\Models\Permission;
 use App\Ship\Parents\Repositories\Repository;
 
 class PermissionRepository extends Repository
@@ -15,6 +14,6 @@ class PermissionRepository extends Repository
 
     public function model(): string
     {
-        return Permission::class;
+        return config('permission.models.permission');
     }
 }

--- a/app/Containers/AppSection/Authorization/Data/Repositories/RoleRepository.php
+++ b/app/Containers/AppSection/Authorization/Data/Repositories/RoleRepository.php
@@ -2,7 +2,6 @@
 
 namespace App\Containers\AppSection\Authorization\Data\Repositories;
 
-use App\Containers\AppSection\Authorization\Models\Role;
 use App\Ship\Parents\Repositories\Repository;
 
 class RoleRepository extends Repository
@@ -15,6 +14,6 @@ class RoleRepository extends Repository
 
     public function model(): string
     {
-        return Role::class;
+        return config('permission.models.role');
     }
 }

--- a/app/Containers/AppSection/Authorization/Tasks/FindPermissionTask.php
+++ b/app/Containers/AppSection/Authorization/Tasks/FindPermissionTask.php
@@ -5,6 +5,7 @@ namespace App\Containers\AppSection\Authorization\Tasks;
 use App\Containers\AppSection\Authorization\Data\Repositories\PermissionRepository;
 use App\Containers\AppSection\Authorization\Models\Permission;
 use App\Ship\Parents\Tasks\Task;
+use Illuminate\Support\Str;
 
 class FindPermissionTask extends Task
 {
@@ -17,7 +18,7 @@ class FindPermissionTask extends Task
 
     public function run($permissionNameOrId): Permission
     {
-        $query = is_numeric($permissionNameOrId) ? ['id' => $permissionNameOrId] : ['name' => $permissionNameOrId];
+        $query = (is_numeric($permissionNameOrId) || Str::isUuid($permissionNameOrId)) ? ['id' => $permissionNameOrId] : ['name' => $permissionNameOrId];
 
         return $this->repository->findWhere($query)->first();
     }

--- a/app/Containers/AppSection/Authorization/Tasks/FindRoleTask.php
+++ b/app/Containers/AppSection/Authorization/Tasks/FindRoleTask.php
@@ -5,6 +5,7 @@ namespace App\Containers\AppSection\Authorization\Tasks;
 use App\Containers\AppSection\Authorization\Data\Repositories\RoleRepository;
 use App\Containers\AppSection\Authorization\Models\Role;
 use App\Ship\Parents\Tasks\Task;
+use Illuminate\Support\Str;
 
 class FindRoleTask extends Task
 {
@@ -17,7 +18,7 @@ class FindRoleTask extends Task
 
     public function run($roleNameOrId): Role
     {
-        $query = is_numeric($roleNameOrId) ? ['id' => $roleNameOrId] : ['name' => $roleNameOrId];
+        $query = (is_numeric($roleNameOrId) || Str::isUuid($roleNameOrId)) ? ['id' => $roleNameOrId] : ['name' => $roleNameOrId];
 
         return $this->repository->findWhere($query)->first();
     }

--- a/app/Containers/AppSection/User/Data/Repositories/UserRepository.php
+++ b/app/Containers/AppSection/User/Data/Repositories/UserRepository.php
@@ -13,4 +13,9 @@ class UserRepository extends Repository
         'email_verified_at' => '=',
         'created_at' => 'like',
     ];
+    
+    public function model(): string
+    {
+        return config('auth.providers.users.model');
+    }
 }


### PR DESCRIPTION
## Description
There is an option in Laravel to replace the user model with your own model, but in the user container, the user repository automatically binds itself with the user model provided in the user container. Similarly, Spatie Laravel permission allows extending permission and role models, but these were bonded in a hardcoded way through the repository model function.

This pull request updates UserRepository, RoleRepository, PermissionRepository to fix the limitation explained above.

Another issue is in FindRoleTask and FindPermissionTask, it checks parameter type, to decide whether it is id or name. But this check fails when the id type is UUID. This pull request updates these tasks to check if param type is numeric or string of type UUID search in id column else in name column

## Motivation and Context
I was trying to use my custom user, role, and permission models, but was not able to use them because respective repositories were bound to models in a hardcoded way.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style and structure of this project.
- [] I have updated the documentation accordingly.
