### PR TITLE
Allow Role and Permission table bindings in Authorization Container (Requests, Tests)

### DIFF
--- a/app/Containers/AppSection/Authorization/UI/API/Requests/AssignUserToRoleRequest.php
+++ b/app/Containers/AppSection/Authorization/UI/API/Requests/AssignUserToRoleRequest.php
@@ -34,7 +34,7 @@ class AssignUserToRoleRequest extends Request
     {
         return [
             'roles_ids' => 'array|required',
-            'roles_ids.*' => 'exists:roles,id',
+            'roles_ids.*' => 'exists:' . config('permission.table_names.roles') . ',id',
             'user_id' => 'required|exists:users,id',
         ];
     }

--- a/app/Containers/AppSection/Authorization/UI/API/Requests/AttachPermissionToRoleRequest.php
+++ b/app/Containers/AppSection/Authorization/UI/API/Requests/AttachPermissionToRoleRequest.php
@@ -34,8 +34,8 @@ class AttachPermissionToRoleRequest extends Request
     {
         return [
             'permissions_ids' => 'required',
-            'permissions_ids.*' => 'exists:permissions,id',
-            'role_id' => 'required|exists:roles,id',
+            'permissions_ids.*' => 'exists:' . config('permission.table_names.permissions') . ',id',
+            'role_id' => 'required|exists:' . config('permission.table_names.roles') . ',id',
         ];
     }
 

--- a/app/Containers/AppSection/Authorization/UI/API/Requests/CreateRoleRequest.php
+++ b/app/Containers/AppSection/Authorization/UI/API/Requests/CreateRoleRequest.php
@@ -32,7 +32,7 @@ class CreateRoleRequest extends Request
     public function rules(): array
     {
         return [
-            'name' => 'required|unique:roles,name|min:2|max:20|no_spaces',
+            'name' => 'required|unique:' . config('permission.table_names.roles') . ',name|min:2|max:20|no_spaces',
             'description' => 'max:255',
             'display_name' => 'max:100',
         ];

--- a/app/Containers/AppSection/Authorization/UI/API/Requests/DeleteRoleRequest.php
+++ b/app/Containers/AppSection/Authorization/UI/API/Requests/DeleteRoleRequest.php
@@ -32,7 +32,7 @@ class DeleteRoleRequest extends Request
     public function rules(): array
     {
         return [
-            'id' => 'required|exists:roles,id'
+            'id' => 'required|exists:' . config('permission.table_names.roles') . ',id'
         ];
     }
 

--- a/app/Containers/AppSection/Authorization/UI/API/Requests/DetachPermissionToRoleRequest.php
+++ b/app/Containers/AppSection/Authorization/UI/API/Requests/DetachPermissionToRoleRequest.php
@@ -33,9 +33,9 @@ class DetachPermissionToRoleRequest extends Request
     public function rules(): array
     {
         return [
-            'role_id' => 'required|exists:roles,id',
+            'role_id' => 'required|exists:' . config('permission.table_names.roles') . ',id',
             'permissions_ids' => 'required',
-            'permissions_ids.*' => 'exists:permissions,id',
+            'permissions_ids.*' => 'exists:' . config('permission.table_names.permissions') . ',id',
         ];
     }
 

--- a/app/Containers/AppSection/Authorization/UI/API/Requests/FindPermissionRequest.php
+++ b/app/Containers/AppSection/Authorization/UI/API/Requests/FindPermissionRequest.php
@@ -32,7 +32,7 @@ class FindPermissionRequest extends Request
     public function rules(): array
     {
         return [
-            'id' => 'required|exists:permissions,id'
+            'id' => 'required|exists:' . config('permission.table_names.permissions') . ',id'
         ];
     }
 

--- a/app/Containers/AppSection/Authorization/UI/API/Requests/FindRoleRequest.php
+++ b/app/Containers/AppSection/Authorization/UI/API/Requests/FindRoleRequest.php
@@ -32,7 +32,7 @@ class FindRoleRequest extends Request
     public function rules(): array
     {
         return [
-            'id' => 'required|exists:roles,id'
+            'id' => 'required|exists:' . config('permission.table_names.roles') . ',id'
         ];
     }
 

--- a/app/Containers/AppSection/Authorization/UI/API/Requests/RevokeUserFromRoleRequest.php
+++ b/app/Containers/AppSection/Authorization/UI/API/Requests/RevokeUserFromRoleRequest.php
@@ -34,7 +34,7 @@ class RevokeUserFromRoleRequest extends Request
     {
         return [
             'roles_ids' => 'required',
-            'roles_ids.*' => 'exists:roles,id',
+            'roles_ids.*' => 'exists:' . config('permission.table_names.roles') . ',id',
             'user_id' => 'required|exists:users,id',
         ];
     }

--- a/app/Containers/AppSection/Authorization/UI/API/Requests/SyncPermissionsOnRoleRequest.php
+++ b/app/Containers/AppSection/Authorization/UI/API/Requests/SyncPermissionsOnRoleRequest.php
@@ -34,8 +34,8 @@ class SyncPermissionsOnRoleRequest extends Request
     {
         return [
             'permissions_ids' => 'required',
-            'permissions_ids.*' => 'exists:permissions,id',
-            'role_id' => 'required|exists:roles,id',
+            'permissions_ids.*' => 'exists:' . config('permission.table_names.permissions') . ',id',
+            'role_id' => 'required|exists:' . config('permission.table_names.roles') . ',id',
         ];
     }
 

--- a/app/Containers/AppSection/Authorization/UI/API/Requests/SyncUserRolesRequest.php
+++ b/app/Containers/AppSection/Authorization/UI/API/Requests/SyncUserRolesRequest.php
@@ -34,7 +34,7 @@ class SyncUserRolesRequest extends Request
     {
         return [
             'roles_ids' => 'required',
-            'roles_ids.*' => 'exists:roles,id',
+            'roles_ids.*' => 'exists:' . config('permission.table_names.roles') . ',id',
             'user_id' => 'required|exists:users,id',
         ];
     }

--- a/app/Containers/AppSection/Authorization/UI/API/Tests/Functional/AttachPermissionsToRoleTest.php
+++ b/app/Containers/AppSection/Authorization/UI/API/Tests/Functional/AttachPermissionsToRoleTest.php
@@ -37,7 +37,7 @@ class AttachPermissionsToRoleTest extends ApiTestCase
         $response->assertStatus(200);
         $responseContent = $this->getResponseContentObject();
         self::assertEquals($roleA['name'], $responseContent->data->name);
-        $this->assertDatabaseHas('role_has_permissions', [
+        $this->assertDatabaseHas(config('permission.table_names.role_has_permissions'), [
             'permission_id' => $permissionA->id,
             'role_id' => $roleA->id
         ]);
@@ -56,7 +56,7 @@ class AttachPermissionsToRoleTest extends ApiTestCase
         $response = $this->makeCall($data);
 
         $response->assertStatus(200);
-        $this->assertDatabaseHas('role_has_permissions', [
+        $this->assertDatabaseHas(config('permission.table_names.role_has_permissions'), [
             'permission_id' => $permissionA->id,
             'permission_id' => $permissionB->id,
             'role_id' => $roleA->id

--- a/app/Containers/AppSection/Authorization/UI/API/Tests/Functional/DetachPermissionsFromRoleTest.php
+++ b/app/Containers/AppSection/Authorization/UI/API/Tests/Functional/DetachPermissionsFromRoleTest.php
@@ -38,7 +38,7 @@ class DetachPermissionsFromRoleTest extends ApiTestCase
         $response->assertStatus(200);
         $responseContent = $this->getResponseContentObject();
         self::assertEquals($roleA->name, $responseContent->data->name);
-        $this->assertDatabaseMissing('role_has_permissions', [
+        $this->assertDatabaseMissing(config('permission.table_names.role_has_permissions'), [
             'permission_id' => $permissionA->id,
             'role_id' => $roleA->id
         ]);
@@ -61,7 +61,7 @@ class DetachPermissionsFromRoleTest extends ApiTestCase
         $response->assertStatus(200);
         $responseContent = $this->getResponseContentObject();
         self::assertEquals($roleA->name, $responseContent->data->name);
-        $this->assertDatabaseMissing('role_has_permissions', [
+        $this->assertDatabaseMissing(config('permission.table_names.role_has_permissions'), [
             'permission_id' => $permissionA->id,
             'permission_id' => $permissionB->id,
             'role_id' => $roleA->id

--- a/app/Containers/AppSection/Authorization/UI/API/Tests/Functional/RevokeUserFromRoleTest.php
+++ b/app/Containers/AppSection/Authorization/UI/API/Tests/Functional/RevokeUserFromRoleTest.php
@@ -38,7 +38,7 @@ class RevokeUserFromRoleTest extends ApiTestCase
         $response->assertStatus(200);
         $responseContent = $this->getResponseContentObject();
         self::assertEquals($data['user_id'], $responseContent->data->id);
-        $this->assertDatabaseMissing('model_has_roles', [
+        $this->assertDatabaseMissing(config('permission.table_names.model_has_roles'), [
             'model_id' => $randomUser->id,
             'role_id' => $roleA->id,
         ]);
@@ -60,11 +60,11 @@ class RevokeUserFromRoleTest extends ApiTestCase
         $response = $this->makeCall($data);
 
         $response->assertStatus(200);
-        $this->assertDatabaseMissing('model_has_roles', [
+        $this->assertDatabaseMissing(config('permission.table_names.model_has_roles'), [
             'model_id' => $randomUser->id,
             'role_id' => $roleA->id,
         ]);
-        $this->assertDatabaseMissing('model_has_roles', [
+        $this->assertDatabaseMissing(config('permission.table_names.model_has_roles'), [
             'model_id' => $randomUser->id,
             'role_id' => $roleB->id,
         ]);

--- a/app/Containers/AppSection/Authorization/UI/API/Tests/Functional/SyncPermissionsOnRoleTest.php
+++ b/app/Containers/AppSection/Authorization/UI/API/Tests/Functional/SyncPermissionsOnRoleTest.php
@@ -37,7 +37,7 @@ class SyncPermissionsOnRoleTest extends ApiTestCase
         $response = $this->makeCall($data);
 
         $response->assertStatus(200);
-        $this->assertDatabaseHas('role_has_permissions', [
+        $this->assertDatabaseHas(config('permission.table_names.role_has_permissions'), [
             'permission_id' => $permissionA->id,
             'permission_id' => $permissionB->id,
             'role_id' => $roleA->id


### PR DESCRIPTION
<!--- If you are unsure which branch your pull request should be sent to, please read: http://apiato.io/docs/general/contribution-guide#git-branches -->

## Description
There is an option in Laravel spatie/laravel-permission package to define custom table names. But the default names are hardcoded in Requests and Tests of the Authorization container

## Motivation and Context
I use custom table names for roles and permissions and associated API Requests and Tests fails with `table not found` error

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).
- [] New feature (non-breaking change which adds functionality).
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Definition of Done Checklist:
- [x] My code follows the code style and structure of this project.
- [] I have updated the documentation accordingly.
