### PR TITLE
fix wrong api url

### DIFF
--- a/app/Containers/AppSection/Authentication/Tasks/CallOAuthServerTask.php
+++ b/app/Containers/AppSection/Authentication/Tasks/CallOAuthServerTask.php
@@ -10,11 +10,9 @@ use Illuminate\Support\Facades\App;
 
 class CallOAuthServerTask extends Task
 {
-    private const AUTH_ROUTE = '/v1/oauth/token';
-
     public function run(array $data, string $languageHeader = null): array
     {
-        $authFullApiUrl = config('apiato.api.url') . self::AUTH_ROUTE;
+        $authFullApiUrl = route('passport.token');
 
         $headers = [
             'HTTP_ACCEPT' => 'application/json',


### PR DESCRIPTION
## Description
Fix wrong api url

## Motivation and Context
The old code did not take into account the API prefix, which led to a call to the wrong url.

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue).

## Definition of Done Checklist:
- [x] My code follows the code style and structure of this project.
- [x] I have updated the documentation accordingly.
