### PR TITLE
lowercased test email address in order to fix failed authorization un…

### DIFF
--- a/app/Containers/AppSection/Authentication/Tests/Unit/CreateUserByCredentialsTaskTest.php
+++ b/app/Containers/AppSection/Authentication/Tests/Unit/CreateUserByCredentialsTaskTest.php
@@ -17,7 +17,7 @@ class CreateUserByCredentialsTaskTest extends TestCase
     public function testCreateUserByCredentials(): void
     {
         $data = [
-            'email' => 'Mahmoud@test.test',
+            'email' => 'mahmoud@test.test',
             'password' => 'so-secret',
         ];
 
@@ -32,7 +32,7 @@ class CreateUserByCredentialsTaskTest extends TestCase
         $this->expectExceptionMessage('Failed to create Resource.');
 
         $data = [
-            'email' => 'Mahmoud@test.test',
+            'email' => 'mahmoud@test.test',
             'password' => 'so-secret',
             'birth' => 'wrong-format',
         ];

--- a/app/Containers/AppSection/Authentication/Tests/Unit/LoginCustomAttributeTest.php
+++ b/app/Containers/AppSection/Authentication/Tests/Unit/LoginCustomAttributeTest.php
@@ -17,7 +17,7 @@ class LoginCustomAttributeTest extends TestCase
     public function testGivenValidLoginAttributeThenExtractUsername(): void
     {
         $userDetails = [
-            'email' => 'Mahmoud@test.test',
+            'email' => 'mahmoud@test.test',
             'password' => 'so-secret',
         ];
 
@@ -37,7 +37,7 @@ class LoginCustomAttributeTest extends TestCase
     {
         Config::offsetUnset('appSection-authentication.login.attributes');
         $userDetails = [
-            'email' => 'Mahmoud@test.test',
+            'email' => 'mahmoud@test.test',
             'password' => 'so-secret',
         ];
 

--- a/app/Containers/AppSection/Authentication/Tests/Unit/RegisterUserActionTest.php
+++ b/app/Containers/AppSection/Authentication/Tests/Unit/RegisterUserActionTest.php
@@ -25,7 +25,7 @@ class RegisterUserActionTest extends TestCase
         Notification::fake();
         config(['appSection-authentication.require_email_verification', false]);
         $data = [
-            'email' => 'Mahmoud@test.test',
+            'email' => 'mahmoud@test.test',
             'password' => 'so-secret',
             'verification_url' => config('appSection-authentication.allowed-verify-email-urls')[0],
         ];
@@ -47,7 +47,7 @@ class RegisterUserActionTest extends TestCase
         }
         Notification::fake();
         $data = [
-            'email' => 'Mahmoud@test.test',
+            'email' => 'mahmoud@test.test',
             'password' => 'so-secret',
             'verification_url' => config('appSection-authentication.allowed-verify-email-urls')[0],
         ];

--- a/app/Containers/AppSection/Authentication/Tests/Unit/WebLoginActionTest.php
+++ b/app/Containers/AppSection/Authentication/Tests/Unit/WebLoginActionTest.php
@@ -63,7 +63,7 @@ class WebLoginActionTest extends TestCase
     {
         parent::setUp();
         $this->userDetails = [
-            'email' => 'Mahmoud@test.test',
+            'email' => 'mahmoud@test.test',
             'password' => 'so-secret',
             'name' => 'Mahmoud',
         ];


### PR DESCRIPTION

## Description
in some tests, Mahmoud@test.com compared to mahmoud@test.com which caused failed assertions and I fixed them by email address normalization.

## Motivation and Context
Fixed failed authorization unit tests

## Types of Changes
- Bug fix (non-breaking change which fixes an issue).
