### PR TITLE
Update mysql collation

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -53,7 +53,7 @@ return [
             'password' => env('DB_PASSWORD', ''),
             'unix_socket' => env('DB_SOCKET', ''),
             'charset' => 'utf8mb4',
-            'collation' => 'utf8mb4_unicode_ci',
+            'collation' => 'utf8mb4_0900_as_cs',
             'prefix' => '',
             'prefix_indexes' => true,
             'strict' => true,


### PR DESCRIPTION

## Description
[//]: # (Please include a summary of the change and which issue is fixed.)
I have updated mysql collation to case sensitive to fix case sensitivity for user email field while login.
Particularly while running `WebLoginActionTest`:
```
./vendor/bin/phpunit --stop-on-failure --stop-on-error ./app/Containers/AppSection/Authentication/Tests/Unit/Actions/WebLoginActionTest.php --filter testCaseSensitiveLogin
```
Using mysql case insensitive collation `utf8mb4_unicode_ci` this test fails:
```
App\Containers\AppSection\Authentication\Tests\Unit\Actions\WebLoginActionTest::testCaseSensitiveLogin with data set #1 ('gandalf@the.grey', 'gAndAlf@thE.gReY', false, 'email')
The user is authenticated
Failed asserting that true is false.
```
With updated collation tests run without failures.

[//]: # (Please also include relevant motivation and context.)
I think other databases in config file are case sensitive by default.
This is why I believe we should set collation to make mysql behave similarly.

Another way is to specify somehow case sensitive comparison specifically for mysql (using BINARY keyword) maybe in QueryBuilder. I don't think this is right way.

[//]: # (List any dependencies that are required for this change.)
I tested it with mysql:8.0 LTS and mysql:8.4 LTS

## Type of change
[//]: # (Please put an x in the box that apply.)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (refactoring a current feature, method, etc...)
- [ ] Code Coverage (adding/removing/updating/refactoring tests)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Remove feature (non-breaking change which removes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

