### PR TITLE
Fix #775 Update .php-cs-fixer.dist.php

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -7,9 +7,8 @@ $finder = Finder::create()
         __DIR__ . '/app',
     ])
     ->name('*.php')
-    ->notName('*.blade.php')
-    ->exclude('Containers/Vendor')
-    ->notName('_*');
+    ->notName(['*.blade.php', '_*'])
+    ->exclude('Containers/Vendor');
 
 return (new PhpCsFixer\Config())
     ->setRules([


### PR DESCRIPTION
## Description
The ->notName() condition cannot be used 2 times.
More details: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/4716

## Type of change
[//]: # (Please put an x in the box that apply.)


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (refactoring a current feature, method, etc...)
- [ ] Code Coverage (adding/removing/updating/refactoring tests)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Remove feature (non-breaking change which removes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

